### PR TITLE
feat(login): refactor login to use command runner service

### DIFF
--- a/cmd/kubecfg/login.go
+++ b/cmd/kubecfg/login.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path"
 	"time"
 
-	"k8s.io/client-go/tools/clientcmd"
-
+	"github.com/amimof/kubecfg/pkg/command"
 	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/amimof/kubecfg/pkg/service"
 	"github.com/spf13/cobra"
 )
 
@@ -62,52 +60,21 @@ func runLoginCmd(workspaceName, kubeconfigName, contextName string) error {
 
 	// Find the credential source using workspace and kubeconfig name
 	rk := runtime.Workspace(workspaceName).Kubeconfig(kubeconfigName)
-	credSource := rk.Contexts[contextName].AuthInfo.CredentialSource
+	aui := rk.Contexts[contextName].AuthInfo
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Create temporary file where kubeconfig is written to by the exec command
-	tmpFile, err := os.CreateTemp("/tmp", "kubecfg-login")
+	runner := command.NewExecCommandRunner()
+	loginService := service.LoginService{Runner: runner, Stdout: loginStdout, Stderr: loginStderr}
+	newAuth, err := loginService.Login(ctx, aui)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := tmpFile.Close(); err != nil {
-			panic(err)
-		}
-		if err := os.Remove(tmpFile.Name()); err != nil {
-			panic(err)
-		}
-	}()
-
-	// Create command
-	c := exec.CommandContext(ctx, credSource.Command, credSource.Args...)
-	c.Env = credSource.Env
-	c.Env = append(c.Env, fmt.Sprintf("%s=%s", "KUBECONFIG", path.Join(tmpFile.Name())))
-	c.Stdout = loginStdout
-	c.Stderr = loginStderr
-
-	// Run command and stream output to avoid pipe deadlocks.
-	if err := c.Run(); err != nil {
-		return err
-	}
-
-	// Read temporary kubeconfig to extract token
-	kubeconfig, err := clientcmd.LoadFromFile(tmpFile.Name())
-	if err != nil {
-		return err
-	}
-
-	if _, ok := kubeconfig.Contexts[credSource.Import.Context]; !ok {
-		return fmt.Errorf("could not import auth info from context %s", credSource.Import.Context)
-	}
-
-	authInfoRef := kubeconfig.Contexts[credSource.Import.Context].AuthInfo
-	authInfo := kubeconfig.AuthInfos[authInfoRef]
 
 	rkContextRef := rk.Context(contextName)
-	rk.Config.AuthInfos[rkContextRef.Name] = authInfo
+	rk.Config.AuthInfos[rkContextRef.AuthInfo.Name] = newAuth
+	rk.Config.CurrentContext = contextName
 
 	if err := writeKubeconfig(rk.Path, *rk.Config); err != nil {
 		return err

--- a/cmd/kubecfg/login_test.go
+++ b/cmd/kubecfg/login_test.go
@@ -40,13 +40,49 @@ func TestRunLoginCmdStreamsSubprocessOutputAndImportsAuthInfo(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, stdout.Len(), 64*1024)
 	require.Greater(t, stderr.Len(), 64*1024)
+	require.Contains(t, stdout.String(), "stdout-data")
+	require.Contains(t, stderr.String(), "stderr-data")
 
 	loaded, err := clientcmd.LoadFromFile(targetPath)
 	require.NoError(t, err)
 
-	authInfo, ok := loaded.AuthInfos["ctx1"]
+	authInfo, ok := loaded.AuthInfos["login-user"]
 	require.True(t, ok)
 	require.Equal(t, "imported-token", authInfo.Token)
+	require.Equal(t, "login-user", loaded.Contexts["ctx1"].AuthInfo)
+}
+
+func TestRunLoginCmdDoesNotMutateCredentialSourceEnv(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "target-kubeconfig.yaml")
+
+	originalCfg := cfg
+	originalBaseDir := baseDir
+	originalStdout := loginStdout
+	originalStderr := loginStderr
+	t.Cleanup(func() {
+		cfg = originalCfg
+		baseDir = originalBaseDir
+		loginStdout = originalStdout
+		loginStderr = originalStderr
+	})
+
+	cfg = newLoginCommandTestConfig(targetPath)
+	baseDir = filepath.Dir(targetPath)
+	loginStdout = io.Discard
+	loginStderr = io.Discard
+
+	compiler := config.NewCompiler(baseDir)
+	runtime, err := compiler.Compile(&cfg)
+	require.NoError(t, err)
+
+	auth := runtime.Workspace("work").Kubeconfig("vgr").Context("ctx1").AuthInfo
+	source, ok := auth.CredentialSource.(*config.RuntimeLoginCredentialSource)
+	require.True(t, ok)
+	require.NotContains(t, source.Env, "KUBECONFIG")
+
+	err = runLoginCmd("work", "vgr", "ctx1")
+	require.NoError(t, err)
+	require.NotContains(t, source.Env, "KUBECONFIG")
 }
 
 func TestHelperProcessLoginCommand(t *testing.T) {

--- a/cmd/kubecfg/use.go
+++ b/cmd/kubecfg/use.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/amimof/kubecfg/pkg/config"
@@ -52,6 +53,20 @@ func writeKubeconfig(path string, kubeconfig api.Config) error {
 	return os.Chmod(path, 0o600)
 }
 
+// setConfig creates a new symlink to a kubeconfigfile overwriting any existing one
+func setConfig(name string) error {
+	dst := path.Join(baseDir, "config")
+	// Remove existing symlink to config so we don't run into an error
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		err := os.Remove(dst)
+		if err != nil {
+			return err
+		}
+	}
+	// Create the symlink to config
+	return os.Symlink(name, path.Join(baseDir, "config"))
+}
+
 func runUseCmd(workspaceName, kubeconfigName string) error {
 	compiler := config.NewCompiler(baseDir)
 
@@ -85,6 +100,11 @@ func runUseCmd(workspaceName, kubeconfigName string) error {
 	if err := writeKubeconfig(rk.Path, *rk.Config); err != nil {
 		return err
 	}
+
+	if err := setConfig(rk.Path); err != nil {
+		return err
+	}
+
 	fmt.Printf("Using kubeconfig: %s/%s\n", workspaceName, kubeconfigName)
 	return nil
 }
@@ -107,6 +127,9 @@ func runUseCmdFzf(workspaceName string) error {
 
 	rk := runtime.Workspace(workspace).Kubeconfig(selected)
 	if err := writeKubeconfig(rk.Path, *rk.Config); err != nil {
+		return err
+	}
+	if err := setConfig(rk.Path); err != nil {
 		return err
 	}
 	fmt.Printf("Using kubeconfig: %s/%s\n", workspace, selected)

--- a/cmd/kubecfg/use_test.go
+++ b/cmd/kubecfg/use_test.go
@@ -127,6 +127,42 @@ func TestRunUseCmdFzfNoSelectionIsNoOp(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
+func TestRunUseCmdFzfUpdatesActiveConfigSymlink(t *testing.T) {
+	t.Setenv("FZF_DEFAULT_OPTS", "")
+	t.Setenv("FZF_DEFAULT_OPTS_FILE", "")
+
+	tmpDir := t.TempDir()
+	targetPath := filepath.Join(tmpDir, "target-kubeconfig.yaml")
+
+	originalCfg := cfg
+	originalBaseDir := baseDir
+	originalFzfRun := fzfRun
+	t.Cleanup(func() {
+		cfg = originalCfg
+		baseDir = originalBaseDir
+		fzfRun = originalFzfRun
+	})
+
+	cfg = newUseCommandTestConfig(targetPath)
+	baseDir = tmpDir
+	fzfRun = func(options *fzf.Options) (int, error) {
+		for range options.Input {
+		}
+		options.Output <- "work/vgr"
+		return fzf.ExitOk, nil
+	}
+
+	err := runUseCmdFzf("")
+	require.NoError(t, err)
+
+	linkPath := filepath.Join(baseDir, "config")
+	linkedTo, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	require.Equal(t, targetPath, linkedTo)
+	_, err = os.Stat(targetPath)
+	require.NoError(t, err)
+}
+
 func TestWriteKubeconfigSetsSecurePermissions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission bits are not reliable on Windows")

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -1,0 +1,175 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type CommandRunner interface {
+	Run(ctx context.Context, spec CommandSpec) (*CommandResult, error)
+}
+
+type CommandSpec struct {
+	Command string
+	Args    []string
+
+	Env map[string]string
+	Dir string
+
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	Redact []string
+}
+
+type CommandResult struct {
+	ExitCode int
+
+	Stdout []byte
+	Stderr []byte
+}
+
+type ExecCommandRunner struct{}
+
+func NewExecCommandRunner() *ExecCommandRunner {
+	return &ExecCommandRunner{}
+}
+
+func (c *ExecCommandRunner) Run(ctx context.Context, spec CommandSpec) (*CommandResult, error) {
+	if strings.TrimSpace(spec.Command) == "" {
+		return nil, fmt.Errorf("command is required")
+	}
+
+	// Create command
+	cmd := exec.CommandContext(ctx, spec.Command, spec.Args...)
+	cmd.Env = mergeEnv(os.Environ(), spec.Env)
+	cmd.Dir = spec.Dir
+	cmd.Stdin = spec.Stdin
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = spec.Stdout
+	cmd.Stderr = spec.Stderr
+
+	if spec.Stdout == nil {
+		cmd.Stdout = &stdout
+	}
+
+	if spec.Stderr == nil {
+		cmd.Stderr = &stderr
+	}
+
+	// Run command and stream output to avoid pipe deadlocks.
+	err := cmd.Run()
+
+	result := &CommandResult{
+		ExitCode: exitCode(err),
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+	}
+
+	if err != nil {
+		return result, &CommandError{
+			Command:  spec.Command,
+			Args:     spec.Args,
+			ExitCode: result.ExitCode,
+			Stdout:   redactBytes(result.Stdout, spec.Redact),
+			Stderr:   redactBytes(result.Stderr, spec.Redact),
+			Err:      err,
+		}
+	}
+
+	return result, nil
+}
+
+type CommandError struct {
+	Command  string
+	Args     []string
+	ExitCode int
+
+	Stdout []byte
+	Stderr []byte
+
+	Err error
+}
+
+func (e *CommandError) Error() string {
+	return fmt.Sprintf(
+		"command %q failed with exit code %d: %s",
+		e.Command,
+		e.ExitCode,
+		strings.TrimSpace(string(e.Stderr)),
+	)
+}
+
+func (e *CommandError) Unwrap() error {
+	return e.Err
+}
+
+func redactBytes(data []byte, secrets []string) []byte {
+	if len(data) == 0 || len(secrets) == 0 {
+		return data
+	}
+
+	s := string(data)
+
+	for _, secret := range secrets {
+		if secret == "" {
+			continue
+		}
+
+		s = strings.ReplaceAll(s, secret, "REDACTED")
+	}
+
+	return []byte(s)
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		return exitErr.ExitCode()
+	}
+
+	return -1
+}
+
+func mergeEnv(base []string, extra map[string]string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+
+	env := make(map[string]string, len(base)+len(extra))
+
+	for _, item := range base {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+
+		env[key] = value
+	}
+
+	maps.Copy(env, extra)
+
+	out := make([]string, 0, len(env))
+	for key, value := range env {
+		out = append(out, key+"="+value)
+	}
+
+	sort.Strings(out)
+
+	return out
+}

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -1,0 +1,54 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCommandRunnerHonorsDirAndStdin(t *testing.T) {
+	if os.Getenv("GO_WANT_COMMAND_HELPER_PROCESS") == "1" {
+		helpCommandRunnerProcess(t)
+		return
+	}
+
+	runner := NewExecCommandRunner()
+	workingDir := t.TempDir()
+	var stdout bytes.Buffer
+
+	_, err := runner.Run(context.Background(), CommandSpec{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestExecCommandRunnerHonorsDirAndStdin", "--"},
+		Env: map[string]string{
+			"GO_WANT_COMMAND_HELPER_PROCESS": "1",
+		},
+		Dir:    workingDir,
+		Stdin:  bytes.NewBufferString("stdin-payload"),
+		Stdout: &stdout,
+	})
+	require.NoError(t, err)
+	resolvedWorkingDir, err := filepath.EvalSymlinks(workingDir)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("cwd=%s\nstdin=stdin-payload\n", resolvedWorkingDir), stdout.String())
+}
+
+func helpCommandRunnerProcess(t *testing.T) {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	stdin, err := io.ReadAll(os.Stdin)
+	require.NoError(t, err)
+
+	_, err = fmt.Fprintf(os.Stdout, "cwd=%s\nstdin=%s\n", filepath.Clean(cwd), string(stdin))
+	require.NoError(t, err)
+
+	os.Exit(0)
+}

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -172,15 +172,29 @@ func compileAuthInfos(rkc *RuntimeKubeconfig, kc *Kubeconfig) error {
 	return nil
 }
 
-func resolveCredentialSource(l *LoginAuth) *RuntimeCredentialSource {
+func envSliceToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+
+	for _, e := range env {
+		key, value, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		m[key] = value
+	}
+
+	return m
+}
+
+func resolveCredentialSource(l *LoginAuth) RuntimeCredentialSource {
 	if l == nil {
 		return nil
 	}
 
-	return &RuntimeCredentialSource{
+	return &RuntimeLoginCredentialSource{
 		Command: l.Command,
 		Args:    l.Args,
-		Env:     l.Env,
+		Env:     envSliceToMap(l.Env),
 		Import: RuntimeLoginImport{
 			Context: l.CopyFromContextName,
 		},

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -122,7 +122,7 @@ type RuntimeAuthInfo struct {
 
 	AuthInfo *api.AuthInfo
 
-	CredentialSource *RuntimeCredentialSource
+	CredentialSource RuntimeCredentialSource
 }
 
 type RuntimeContext struct {
@@ -146,14 +146,31 @@ type RuntimeContextRef struct {
 	Context    *RuntimeContext
 }
 
-type RuntimeCredentialSource struct {
+type RuntimeCredentialSource interface {
+	Type() string
+}
+
+type CredentialSourceType string
+
+const (
+	CredentialSourceNone  CredentialSourceType = "none"
+	CredentialSourceExec  CredentialSourceType = "exec"
+	CredentialSourceLogin CredentialSourceType = "login"
+	CredentialSourceToken CredentialSourceType = "token"
+)
+
+type RuntimeLoginCredentialSource struct {
 	Provider string
 
 	Command string
 	Args    []string
-	Env     []string
+	Env     map[string]string
 
 	Import RuntimeLoginImport
+}
+
+func (e *RuntimeLoginCredentialSource) Type() string {
+	return string(CredentialSourceLogin)
 }
 
 type RuntimeLoginImport struct {

--- a/pkg/service/login.go
+++ b/pkg/service/login.go
@@ -1,0 +1,89 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+
+	"github.com/amimof/kubecfg/pkg/command"
+	"github.com/amimof/kubecfg/pkg/config"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+type LoginService struct {
+	// StateStore CredentialStateStore
+	Runner command.CommandRunner
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (s *LoginService) Login(
+	ctx context.Context,
+	auth *config.RuntimeAuthInfo,
+) (*api.AuthInfo, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("authinfo is nil")
+	}
+
+	switch source := auth.CredentialSource.(type) {
+	case nil:
+		return auth.AuthInfo, nil
+	case *config.RuntimeLoginCredentialSource:
+		return s.loginWithCommand(ctx, auth, source)
+	default:
+		return nil, fmt.Errorf("unsupported credential source %T", source)
+	}
+}
+
+func (s *LoginService) loginWithCommand(ctx context.Context, _ *config.RuntimeAuthInfo, sourceType config.RuntimeCredentialSource) (*api.AuthInfo, error) {
+	source := sourceType.(*config.RuntimeLoginCredentialSource)
+
+	// Create temporary file where kubeconfig is written to by the exec command
+	tmpFile, err := os.CreateTemp("/tmp", "kubecfg-login")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := tmpFile.Close(); err != nil {
+			panic(err)
+		}
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			panic(err)
+		}
+	}()
+
+	// Add var so that login uses temporary kubeconfig file during login
+	env := make(map[string]string, len(source.Env)+1)
+	maps.Copy(env, source.Env)
+	env["KUBECONFIG"] = tmpFile.Name()
+
+	_, err = s.Runner.Run(ctx, command.CommandSpec{
+		Command: source.Command,
+		Args:    source.Args,
+		Env:     env,
+		Dir:     "/tmp",
+		Stdout:  s.Stdout,
+		Stderr:  s.Stderr,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Read temporary kubeconfig to extract token
+	kubeconfig, err := clientcmd.LoadFromFile(tmpFile.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := kubeconfig.Contexts[source.Import.Context]; !ok {
+		return nil, fmt.Errorf("could not import auth info from context %s", source.Import.Context)
+	}
+
+	authInfoRef := kubeconfig.Contexts[source.Import.Context].AuthInfo
+	authInfo := kubeconfig.AuthInfos[authInfoRef]
+
+	return authInfo, nil
+}


### PR DESCRIPTION
Refactored login command to use a new command runner abstraction and LoginService. This improves testability, avoids mutating credential source env, and centralizes subprocess execution logic. Added command runner package and login service. Also, use command now updates the active kubeconfig symlink.