### PR TITLE
feat(use): add login flow before kubeconfig rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ If you manage more than one cluster, `~/.kube` tends to turn into a junk drawer 
    - Run `kubecfg use homelab/mainframe`: Use specific kubeconfig in specific workspace.
    - Run `kubecfg use mainframe --workspace homelab`: Same as previous command.
 
+> See [Examples](/examples/) for more information on how to configure kubecfg in various ways
+
 # Highlights
 - Declarative kubeconfig management from a single YAML file
 - Named workspaces for grouping related kubeconfigs

--- a/cmd/kubecfg/use.go
+++ b/cmd/kubecfg/use.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"strings"
+	"time"
 
+	"github.com/amimof/kubecfg/pkg/command"
 	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/amimof/kubecfg/pkg/service"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -21,7 +25,10 @@ var (
 )
 
 func newUseCmd() *cobra.Command {
-	var workspaceName string
+	var (
+		workspaceName string
+		skipLogin     bool
+	)
 
 	cmd := &cobra.Command{
 		Use:          "use [NAME]",
@@ -31,13 +38,14 @@ func newUseCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return runUseCmdFzf(workspaceName)
+				return runUseCmdFzf(workspaceName, skipLogin)
 			}
-			return runUseCmd(workspaceName, args[0])
+			return runUseCmd(workspaceName, args[0], skipLogin)
 		}),
 	}
 
 	cmd.PersistentFlags().StringVarP(&workspaceName, "workspace", "w", "", "Workspace")
+	cmd.PersistentFlags().BoolVar(&skipLogin, "skip-login", false, "Skip execution of login flow prior to kubeconfig rendering")
 
 	return cmd
 }
@@ -67,7 +75,7 @@ func setConfig(name string) error {
 	return os.Symlink(name, path.Join(baseDir, "config"))
 }
 
-func runUseCmd(workspaceName, kubeconfigName string) error {
+func runUseCmd(workspaceName, kubeconfigName string, skipLogin bool) error {
 	compiler := config.NewCompiler(baseDir)
 
 	runtime, err := compiler.Compile(&cfg)
@@ -102,6 +110,12 @@ func runUseCmd(workspaceName, kubeconfigName string) error {
 		rk.Config.CurrentContext = rk.Name
 	}
 
+	if !skipLogin {
+		if err := runLogin(rk); err != nil {
+			return err
+		}
+	}
+
 	if err := writeKubeconfig(rk.Path, *rk.Config); err != nil {
 		return err
 	}
@@ -114,7 +128,7 @@ func runUseCmd(workspaceName, kubeconfigName string) error {
 	return nil
 }
 
-func runUseCmdFzf(workspaceName string) error {
+func runUseCmdFzf(workspaceName string, skipLogin bool) error {
 	compiler := config.NewCompiler(baseDir)
 
 	runtime, err := compiler.Compile(&cfg)
@@ -136,6 +150,12 @@ func runUseCmdFzf(workspaceName string) error {
 		rk.Config.CurrentContext = rk.Name
 	}
 
+	if !skipLogin {
+		if err := runLogin(rk); err != nil {
+			return err
+		}
+	}
+
 	if err := writeKubeconfig(rk.Path, *rk.Config); err != nil {
 		return err
 	}
@@ -143,6 +163,29 @@ func runUseCmdFzf(workspaceName string) error {
 		return err
 	}
 	fmt.Printf("Using kubeconfig: %s/%s\n", workspace, selected)
+	return nil
+}
+
+func runLogin(rk *config.RuntimeKubeconfig) error {
+	for name, ctx := range rk.Contexts {
+
+		aui := rk.AuthInfo(ctx.AuthInfo.Name)
+
+		if aui.CredentialSource != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			runner := command.NewExecCommandRunner()
+			loginService := service.LoginService{Runner: runner, Stdout: loginStdout, Stderr: loginStderr}
+			newAuth, err := loginService.Login(ctx, aui)
+			if err != nil {
+				return err
+			}
+
+			rk.Config.AuthInfos[name] = newAuth
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/kubecfg/use_test.go
+++ b/cmd/kubecfg/use_test.go
@@ -120,7 +120,7 @@ func TestRunUseCmdFzfNoSelectionIsNoOp(t *testing.T) {
 		return fzf.ExitNoMatch, nil
 	}
 
-	err := runUseCmdFzf("")
+	err := runUseCmdFzf("", false)
 	require.NoError(t, err)
 
 	_, err = os.Stat(targetPath)
@@ -152,7 +152,7 @@ func TestRunUseCmdFzfUpdatesActiveConfigSymlink(t *testing.T) {
 		return fzf.ExitOk, nil
 	}
 
-	err := runUseCmdFzf("")
+	err := runUseCmdFzf("", false)
 	require.NoError(t, err)
 
 	linkPath := filepath.Join(baseDir, "config")

--- a/examples/vmware-tanzu.md
+++ b/examples/vmware-tanzu.md
@@ -1,0 +1,51 @@
+# Using kubecfg with VMware Tanzu
+
+VMware Tanzu clusters often require a distribution-specific login flow before `kubectl` can access a cluster using the `kubectl-vsphere` plugin. Kubecfg supports running distribution specific login flows before the kubeconfig is generated and ready to be used. Here is an example on how to set it up.
+
+## Configuration
+
+Following `kubecfg` kubeconfig declaration allows you to run `kubecfg login [KUBECONFIG] [CONTEXT]`. That will run the `login` command, authenticate the user with Tanzu, export the authentication token and inject it into a rendered kubeconfig.
+
+```yaml
+kubeconfigs:
+  tanzu:
+    clusters:
+      supervisor-prod:
+        name: supervisor-prod
+        server: https://supervisor-prod.amimof.com:6443
+        insecure_skip_tls_verify: true
+    auth_infos:
+      amimof:
+        name: amimof
+        provider: tanzu-vsphere
+        login:
+          command: kubectl-vsphere
+          env:
+          - KUBECTL_VSPHERE_PASSWORD=beyonce
+          args:
+            - login
+            - --server
+            - https://supervisor-api.amimof.com:6443
+            - --tanzu-kubernetes-cluster-name
+            - prod-cluster
+            - --tanzu-kubernetes-cluster-namespace
+            - prod
+            - --insecure-skip-tls-verify
+            - --vsphere-username
+            - amimof
+          copy_from_context_name: supervisor-api.amimof.com
+    contexts:
+      supervisor-prod:
+        name: supervisor-prod
+        cluster: supervisor-prod
+        authinfo: amimof
+
+```
+
+With this configuration you may run the following:
+
+```bash
+kubecfg login tanzu supervisor-prod
+```
+
+> NOTE! The login flow is by default executed with `kubecfg use` if the `auth_info` contains a `login` flow.


### PR DESCRIPTION
Add support for executing a login flow prior to kubeconfig rendering when an auth_info specifies a login command. This enables integration with providers like VMware Tanzu that require a pre-authentication step. Includes a --skip-login flag to bypass the login flow if needed. Also adds an example for VMware Tanzu configuration.