### PR TITLE
feat(kubeconfigs): add kubeconfigs command to list kubeconfigs

### DIFF
--- a/cmd/kubecfg/kubeconfigs.go
+++ b/cmd/kubecfg/kubeconfigs.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var kubeconfigsStdout io.Writer = os.Stdout
+
+func newKubeconfigsCmd() *cobra.Command {
+	var workspaceName string
+
+	cmd := &cobra.Command{
+		Use:          "kubeconfigs",
+		Short:        "list kubeconfigs",
+		Long:         `list kubeconfigs`,
+		Args:         cobra.ExactArgs(0),
+		SilenceUsage: true,
+		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
+			return runKubeconfigsCmd(workspaceName, kubeconfigsStdout)
+		}),
+	}
+
+	cmd.PersistentFlags().StringVarP(&workspaceName, "workspace", "w", "", "Workspace")
+
+	return cmd
+}
+
+func runKubeconfigsCmd(workspaceName string, stdout io.Writer) error {
+	entries, err := collectKubeconfigRows(workspaceName)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "WORKSPACES\tNAME\tPATH\tALIASES\tCONTEXTS"); err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		aliases := strings.Join(entry.kubeconfig.Aliases, ", ")
+		contexts := 0
+		if entry.kubeconfig.Contexts != nil {
+			contexts = len(entry.kubeconfig.Contexts)
+		}
+
+		if _, err := fmt.Fprintf(
+			tw,
+			"%s\t%s\t%s\t%s\t%d\n",
+			strings.Join(entry.workspaces, ", "),
+			entry.name,
+			entry.kubeconfig.Path,
+			aliases,
+			contexts,
+		); err != nil {
+			return err
+		}
+	}
+
+	return tw.Flush()
+}
+
+type kubeconfigTableRow struct {
+	name       string
+	workspaces []string
+	kubeconfig *config.Kubeconfig
+}
+
+func collectKubeconfigRows(workspaceName string) ([]kubeconfigTableRow, error) {
+	workspaceNames := make([]string, 0, len(cfg.Workspaces))
+	if workspaceName != "" {
+		workspace := cfg.Workspace(workspaceName)
+		if workspace == nil {
+			return nil, fmt.Errorf("workspace does not exist: %s", workspaceName)
+		}
+		workspaceNames = append(workspaceNames, workspaceName)
+	} else {
+		for name := range cfg.Workspaces {
+			workspaceNames = append(workspaceNames, name)
+		}
+		sort.Strings(workspaceNames)
+	}
+
+	rowsByName := make(map[string]*kubeconfigTableRow)
+	for _, workspaceName := range workspaceNames {
+		workspace := cfg.Workspace(workspaceName)
+		for _, kubeconfigName := range workspace.Kubeconfigs {
+			kubeconfig := cfg.Kubeconfig(kubeconfigName)
+			if kubeconfig == nil {
+				return nil, fmt.Errorf("workspaces.%s.kubeconfigs references missing kubeconfig %q", workspaceName, kubeconfigName)
+			}
+
+			row, ok := rowsByName[kubeconfigName]
+			if !ok {
+				row = &kubeconfigTableRow{name: kubeconfigName, kubeconfig: kubeconfig}
+				rowsByName[kubeconfigName] = row
+			}
+
+			row.workspaces = append(row.workspaces, workspaceName)
+		}
+	}
+
+	rows := make([]kubeconfigTableRow, 0, len(rowsByName))
+	for _, row := range rowsByName {
+		sort.Strings(row.workspaces)
+		row.workspaces = compactSortedStrings(row.workspaces)
+		rows = append(rows, *row)
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].name < rows[j].name
+	})
+
+	return rows, nil
+}
+
+func compactSortedStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+
+	result := values[:1]
+	for _, value := range values[1:] {
+		if value == result[len(result)-1] {
+			continue
+		}
+		result = append(result, value)
+	}
+
+	return result
+}

--- a/cmd/kubecfg/kubeconfigs_test.go
+++ b/cmd/kubecfg/kubeconfigs_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunKubeconfigsCmdUsesExplicitWorkspace(t *testing.T) {
+	originalCfg := cfg
+	t.Cleanup(func() {
+		cfg = originalCfg
+	})
+
+	cfg = newKubeconfigsCommandTestConfig()
+
+	var stdout bytes.Buffer
+	err := runKubeconfigsCmd("secondary", &stdout)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"WORKSPACES  NAME   PATH         ALIASES  CONTEXTS",
+		"secondary   alpha  /tmp/a.yaml  a1, a2   1",
+		"secondary   beta   /tmp/b.yaml           2",
+	}, strings.Split(strings.TrimSpace(stdout.String()), "\n"))
+}
+
+func TestRunKubeconfigsCmdListsAllWorkspacesWhenFilterIsOmitted(t *testing.T) {
+	originalCfg := cfg
+	t.Cleanup(func() {
+		cfg = originalCfg
+	})
+
+	cfg = newKubeconfigsCommandTestConfig()
+
+	var stdout bytes.Buffer
+	err := runKubeconfigsCmd("", &stdout)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"WORKSPACES          NAME   PATH         ALIASES  CONTEXTS",
+		"secondary           alpha  /tmp/a.yaml  a1, a2   1",
+		"default, secondary  beta   /tmp/b.yaml           2",
+		"default             gamma  /tmp/c.yaml  g        0",
+	}, strings.Split(strings.TrimSpace(stdout.String()), "\n"))
+}
+
+func TestRunKubeconfigsCmdReturnsErrorForUnknownWorkspace(t *testing.T) {
+	originalCfg := cfg
+	t.Cleanup(func() {
+		cfg = originalCfg
+	})
+
+	cfg = newKubeconfigsCommandTestConfig()
+
+	var stdout bytes.Buffer
+	err := runKubeconfigsCmd("missing", &stdout)
+	require.EqualError(t, err, "workspace does not exist: missing")
+}
+
+func TestRunKubeconfigsCmdReturnsErrorForMissingReferencedKubeconfig(t *testing.T) {
+	originalCfg := cfg
+	t.Cleanup(func() {
+		cfg = originalCfg
+	})
+
+	cfg = newKubeconfigsCommandTestConfig()
+	cfg.Workspaces["default"].Kubeconfigs = append(cfg.Workspaces["default"].Kubeconfigs, "missing")
+
+	var stdout bytes.Buffer
+	err := runKubeconfigsCmd("default", &stdout)
+	require.EqualError(t, err, "workspaces.default.kubeconfigs references missing kubeconfig \"missing\"")
+}
+
+func newKubeconfigsCommandTestConfig() config.Config {
+	return config.Config{
+		Version:          "v1",
+		DefaultWorkspace: "default",
+		Workspaces: map[string]*config.Workspace{
+			"default": {
+				Kubeconfigs: []string{"gamma", "beta"},
+			},
+			"secondary": {
+				Kubeconfigs: []string{"beta", "alpha"},
+			},
+		},
+		Kubeconfigs: map[string]*config.Kubeconfig{
+			"alpha": {
+				Path:    "/tmp/a.yaml",
+				Aliases: []string{"a1", "a2"},
+				Contexts: map[string]*config.Context{
+					"admin": {},
+				},
+			},
+			"beta": {
+				Path: "/tmp/b.yaml",
+				Contexts: map[string]*config.Context{
+					"admin": {},
+					"ops":   {},
+				},
+			},
+			"gamma": {
+				Path:    "/tmp/c.yaml",
+				Aliases: []string{"g"},
+			},
+		},
+	}
+}

--- a/cmd/kubecfg/main.go
+++ b/cmd/kubecfg/main.go
@@ -125,6 +125,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "number for the log level verbosity (debug, info, warn, error, fatal, panic)")
 
 	rootCmd.AddCommand(newVersionCmd())
+	rootCmd.AddCommand(newKubeconfigsCmd())
 	rootCmd.AddCommand(newWorkspacesCmd())
 	rootCmd.AddCommand(newUseCmd())
 	rootCmd.AddCommand(newLoginCmd())

--- a/cmd/kubecfg/workspaces.go
+++ b/cmd/kubecfg/workspaces.go
@@ -2,10 +2,16 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"sort"
+	"text/tabwriter"
 
 	"github.com/amimof/kubecfg/pkg/config"
 	"github.com/spf13/cobra"
 )
+
+var workspacesStdout io.Writer = os.Stdout
 
 func newWorkspacesCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -15,13 +21,13 @@ func newWorkspacesCmd() *cobra.Command {
 		Aliases: []string{"ws"},
 		Args:    cobra.ExactArgs(0),
 		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
-			return runWorkspacesCmd()
+			return runWorkspacesCmd(workspacesStdout)
 		}),
 	}
 	return cmd
 }
 
-func runWorkspacesCmd() error {
+func runWorkspacesCmd(stdout io.Writer) error {
 	compiler := config.NewCompiler(baseDir)
 
 	runtime, err := compiler.Compile(&cfg)
@@ -29,9 +35,23 @@ func runWorkspacesCmd() error {
 		return err
 	}
 
-	for name, k := range runtime.Workspaces {
-		fmt.Println(name, k.Description, len(k.Kubeconfigs))
+	names := make([]string, 0, len(runtime.Workspaces))
+	for name := range runtime.Workspaces {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tDESCRIPTION\tKUBECONFIGS"); err != nil {
+		return err
 	}
 
-	return nil
+	for _, name := range names {
+		workspace := runtime.Workspace(name)
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\n", name, workspace.Description, len(workspace.Kubeconfigs)); err != nil {
+			return err
+		}
+	}
+
+	return tw.Flush()
 }

--- a/cmd/kubecfg/workspaces_test.go
+++ b/cmd/kubecfg/workspaces_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWorkspacesCmdPrintsHeaderedTable(t *testing.T) {
+	originalCfg := cfg
+	originalBaseDir := baseDir
+	t.Cleanup(func() {
+		cfg = originalCfg
+		baseDir = originalBaseDir
+	})
+
+	cfg = newWorkspacesCommandTestConfig()
+	baseDir = "/tmp"
+
+	var stdout bytes.Buffer
+	err := runWorkspacesCmd(&stdout)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"NAME       DESCRIPTION         KUBECONFIGS",
+		"default    Main workspace      2",
+		"secondary  Ops clusters        1",
+		"third      Untitled workspace  1",
+	}, strings.Split(strings.TrimSpace(stdout.String()), "\n"))
+}
+
+func newWorkspacesCommandTestConfig() config.Config {
+	return config.Config{
+		Version: "v1",
+		Workspaces: map[string]*config.Workspace{
+			"default": {
+				Description: "Main workspace",
+				Kubeconfigs: []string{"beta", "alpha"},
+			},
+			"secondary": {
+				Description: "Ops clusters",
+				Kubeconfigs: []string{"gamma"},
+			},
+			"third": {
+				Description: "Untitled workspace",
+				Kubeconfigs: []string{"alpha"},
+			},
+		},
+		Kubeconfigs: map[string]*config.Kubeconfig{
+			"alpha": {
+				Path: "/tmp/a.yaml",
+				Clusters: map[string]*config.Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*config.AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*config.Context{
+					"admin": {Cluster: "cluster", AuthInfo: "user"},
+				},
+			},
+			"beta": {
+				Path: "/tmp/b.yaml",
+				Clusters: map[string]*config.Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*config.AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*config.Context{
+					"admin": {Cluster: "cluster", AuthInfo: "user"},
+				},
+			},
+			"gamma": {
+				Path: "/tmp/c.yaml",
+				Clusters: map[string]*config.Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*config.AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*config.Context{
+					"admin": {Cluster: "cluster", AuthInfo: "user"},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Introduce a new "kubeconfigs" command that lists kubeconfigs in a tabular format, optionally filtered by workspace. Also refactor "workspaces" command to output a table. Includes tests for both commands. This improves usability and visibility of kubeconfig associations.