### PR TITLE
feat(config): add default_kubeconfig and default_context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ workspaces:
     # - "<workspace>/<kubeconfig>/<context>"
     # - "<kubeconfig>/<context>"
     # - "<context>" when unique inside this workspace
+    # Overrides kubeconfigs.<name>.current_context when both are set.
     defaultContext: static-token/admin
 
     # Workspace-level fallback namespace. Stored in runtime config, but not
@@ -158,6 +159,11 @@ kubeconfigs:
   static-token:
     # Absolute path, or "@/..." relative to --base-dir.
     path: "@/generated/static-token.yaml"
+
+    # Local context name to render as current-context for this kubeconfig.
+    # This is resolved only within static-token.contexts.
+    # workspace.defaultContext overrides it when both are set.
+    current_context: admin
 
     # Present in the schema, but not currently enforced by CLI commands.
     # protected: true

--- a/cmd/kubecfg/describe_workspace.go
+++ b/cmd/kubecfg/describe_workspace.go
@@ -78,7 +78,7 @@ func renderWorkspaceDescription(stdout io.Writer, rw config.RuntimeWorkspace) er
 		cmdutil.NewContainer(nil,
 			cmdutil.NewElement(`{{ "Name" | FgHiGreen }}:               {{ .Workspace.Name }}`),
 			cmdutil.NewElement(`{{ "Description" | FgHiGreen }}:        {{ .Workspace.Description }}`),
-			cmdutil.NewElement(`{{ "Default Namespace" | FgHiGreen }}:  {{ .Workspace.DefaultNamespace }}`),
+			cmdutil.NewElement(`{{ "Default Kubeconfig" | FgHiGreen }}: {{ .WorkspaceDefaultKubeconfig }}`),
 			cmdutil.NewElement(`{{ "Kubeconfigs" | FgHiGreen }}:        {{ .Workspace.Kubeconfigs | len | string | FgBlue }}`),
 		).WithLayout(cmdutil.Layout{Dimensions: [2]int{1024, 0}}),
 	}
@@ -94,7 +94,9 @@ func renderWorkspaceDescription(stdout io.Writer, rw config.RuntimeWorkspace) er
 			cmdutil.NewElement(`   {{ "Path" | FgHiGreen}}:               {{ .Container.Kubeconfig.Path }}`),
 			cmdutil.NewElement(`   {{ "Aliases" | FgHiGreen}}:            {{ .Container.Kubeconfig.Aliases }}`),
 			cmdutil.NewElement(`   {{ "Protected" | FgHiGreen }}:          {{ .Container.Kubeconfig.Protected | string | FgYellow }}`),
-			cmdutil.NewElement(`   {{ "Current Context" | FgHiGreen }}:    {{ .Container.Kubeconfig.CurrentContext.Name | string }}`),
+			cmdutil.NewElement(`   {{ "Current Context" | FgHiGreen }}:    {{ .Container.Kubeconfig.CurrentContext.Name }}`),
+			cmdutil.NewElement(`   {{ "Default Context" | FgHiGreen }}:    {{ .Container.Kubeconfig.DefaultContext.Name }}`),
+			cmdutil.NewElement(`   {{ "Default Namespace" | FgHiGreen }}:    {{ .Container.Kubeconfig.DefaultNamespace }}`),
 			cmdutil.NewElement(`   {{ "Contexts" | FgHiGreen }}:           {{ .Container.Kubeconfig.Contexts | len | string | FgBlue }}`),
 		).WithLayout(cmdutil.Layout{Dimensions: [2]int{1024, 0}})
 
@@ -118,5 +120,16 @@ func renderWorkspaceDescription(stdout io.Writer, rw config.RuntimeWorkspace) er
 		i += 1
 	}
 
-	return cmdutil.RenderOnce(stdout, cmdutil.Data{"Workspace": rw}, containers...)
+	return cmdutil.RenderOnce(stdout, cmdutil.Data{
+		"Workspace":                  rw,
+		"WorkspaceDefaultKubeconfig": workspaceDefaultKubeconfigDisplay(rw.DefaultKubeconfig),
+	}, containers...)
+}
+
+func workspaceDefaultKubeconfigDisplay(rk *config.RuntimeKubeconfig) string {
+	if rk == nil {
+		return ""
+	}
+
+	return rk.Name
 }

--- a/cmd/kubecfg/describe_workspace_test.go
+++ b/cmd/kubecfg/describe_workspace_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunDescribeWorkspaceCmdRendersDefaultKubeconfig(t *testing.T) {
+	originalCfg := cfg
+	originalBaseDir := baseDir
+	t.Cleanup(func() {
+		cfg = originalCfg
+		baseDir = originalBaseDir
+	})
+
+	cfg = newDescribeWorkspaceTestConfig()
+	baseDir = "/tmp"
+
+	var stdout bytes.Buffer
+	err := runDescribeWorkspaceCmd([]string{"work"}, "", &stdout)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	require.Contains(t, output, "Default Kubeconfig")
+	require.Contains(t, output, "vgr")
+	require.NotContains(t, output, "<nil>")
+}
+
+func TestWorkspaceDefaultKubeconfigDisplay(t *testing.T) {
+	require.Equal(t, "", workspaceDefaultKubeconfigDisplay(nil))
+	require.Equal(t, "vgr", workspaceDefaultKubeconfigDisplay(&config.RuntimeKubeconfig{Name: "vgr"}))
+}
+
+func newDescribeWorkspaceTestConfig() config.Config {
+	return config.Config{
+		Version: "v1",
+		Workspaces: map[string]*config.Workspace{
+			"work": {
+				Kubeconfigs:       []string{"vgr"},
+				DefaultKubeconfig: "vgr",
+			},
+		},
+		Kubeconfigs: map[string]*config.Kubeconfig{
+			"vgr": {
+				Path:           "/tmp/vgr.yaml",
+				DefaultContext: "ops",
+				Clusters: map[string]*config.Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*config.AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*config.Context{
+					"admin": {Cluster: "cluster", AuthInfo: "user"},
+					"ops":   {Cluster: "cluster", AuthInfo: "user"},
+				},
+			},
+		},
+	}
+}
+
+func TestRunDescribeWorkspaceCmdRendersEmptyDefaultKubeconfigWhenUnset(t *testing.T) {
+	originalCfg := cfg
+	originalBaseDir := baseDir
+	t.Cleanup(func() {
+		cfg = originalCfg
+		baseDir = originalBaseDir
+	})
+
+	cfg = newDescribeWorkspaceTestConfig()
+	cfg.Workspaces["work"].DefaultKubeconfig = ""
+	baseDir = "/tmp"
+
+	var stdout bytes.Buffer
+	err := runDescribeWorkspaceCmd([]string{"work"}, "", &stdout)
+	require.NoError(t, err)
+
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if strings.Contains(line, "Default Kubeconfig") {
+			require.NotContains(t, line, "<nil>")
+			return
+		}
+	}
+
+	t.Fatal("default kubeconfig line not found")
+}

--- a/cmd/kubecfg/main.go
+++ b/cmd/kubecfg/main.go
@@ -75,7 +75,6 @@ func loadConfig(validate bool) error {
 			cfg = config.Config{
 				Version:          "v1",
 				DefaultWorkspace: "",
-				DefaultNamespace: "",
 				Kubeconfigs:      make(map[string]*config.Kubeconfig),
 				Workspaces:       make(map[string]*config.Workspace),
 			}

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -40,9 +40,6 @@ func (c *Compiler) Compile(cfg *Config) (*RuntimeConfig, error) {
 	rt := &RuntimeConfig{
 		Version: cfg.Version,
 
-		DefaultWorkspace: cfg.DefaultWorkspace,
-		DefaultNamespace: cfg.DefaultNamespace,
-
 		Workspaces:        make(map[string]*RuntimeWorkspace),
 		Kubeconfigs:       make(map[string]*RuntimeKubeconfig),
 		KubeconfigAliases: make(map[string]*RuntimeKubeconfig),
@@ -71,10 +68,11 @@ func (c *Compiler) compileKubeconfigs(rt *RuntimeConfig, cfg *Config) error {
 		}
 
 		rkc := &RuntimeKubeconfig{
-			Name:      kubeconfigName,
-			Path:      c.resolvePath(kubeconfig.Path),
-			Protected: kubeconfig.Protected,
-			Aliases:   append([]string(nil), kubeconfig.Aliases...),
+			Name:             kubeconfigName,
+			Path:             c.resolvePath(kubeconfig.Path),
+			Protected:        kubeconfig.Protected,
+			Aliases:          append([]string(nil), kubeconfig.Aliases...),
+			DefaultNamespace: strings.TrimSpace(kubeconfig.DefaultNamespace),
 
 			Clusters:  make(map[string]*RuntimeCluster),
 			AuthInfos: make(map[string]*RuntimeAuthInfo),
@@ -100,6 +98,14 @@ func (c *Compiler) compileKubeconfigs(rt *RuntimeConfig, cfg *Config) error {
 		}
 
 		if err := resolveRuntimeContexts(rkc); err != nil {
+			return err
+		}
+
+		if err := resolveKubeconfigCurrentContext(rkc, kubeconfig.CurrentContext); err != nil {
+			return err
+		}
+
+		if err := resolveKubeconfigDefaultContext(rkc, kubeconfig.DefaultContext); err != nil {
 			return err
 		}
 
@@ -219,6 +225,8 @@ func compileContexts(rkc *RuntimeKubeconfig, kc *Kubeconfig) error {
 		runtimeAuthInfo := rkc.AuthInfo(context.AuthInfo)
 		runtimeCluster := rkc.Cluster(context.Cluster)
 
+		namespace := firstNonEmpty(context.Namespace, kc.DefaultNamespace)
+
 		rkc.Contexts[name] = &RuntimeContext{
 			Name: name,
 
@@ -227,13 +235,13 @@ func compileContexts(rkc *RuntimeKubeconfig, kc *Kubeconfig) error {
 
 			ClusterKey:  context.Cluster,
 			AuthInfoKey: context.AuthInfo,
-			Namespace:   context.Namespace,
+			Namespace:   namespace,
 
 			Context: &api.Context{
 				LocationOfOrigin: context.LocationOfOrigin,
 				Cluster:          context.Cluster,
 				AuthInfo:         context.AuthInfo,
-				Namespace:        context.Namespace,
+				Namespace:        namespace,
 				Extensions:       context.Extensions,
 			},
 		}
@@ -271,8 +279,28 @@ func resolveRuntimeContexts(rkc *RuntimeKubeconfig) error {
 		ctx.Context.Cluster = cluster.Name
 		ctx.Context.AuthInfo = authInfo.Name
 		ctx.Context.Namespace = ctx.Namespace
+
 	}
 
+	return nil
+}
+
+func resolveKubeconfigCurrentContext(rkc *RuntimeKubeconfig, currentContext string) error {
+	currentContext = strings.TrimSpace(currentContext)
+	if currentContext == "" {
+		return nil
+	}
+
+	ctx, ok := rkc.Contexts[currentContext]
+	if !ok {
+		return fmt.Errorf(
+			"kubeconfigs.%s.current_context references missing context %q",
+			rkc.Name,
+			currentContext,
+		)
+	}
+
+	rkc.CurrentContext = ctx
 	return nil
 }
 
@@ -307,8 +335,7 @@ func (c *Compiler) compileWorkspaces(rt *RuntimeConfig, cfg *Config) error {
 		rw := &RuntimeWorkspace{
 			Name: workspaceName,
 
-			Description:      workspace.Description,
-			DefaultNamespace: firstNonEmpty(workspace.DefaultNamespace, cfg.DefaultNamespace),
+			Description: workspace.Description,
 
 			Kubeconfigs: make(map[string]*RuntimeKubeconfig),
 		}
@@ -328,6 +355,17 @@ func (c *Compiler) compileWorkspaces(rt *RuntimeConfig, cfg *Config) error {
 			indexWorkspaceContexts(rt, rw, rkc)
 		}
 
+		if workspace.DefaultKubeconfig != "" {
+			rw.DefaultKubeconfig = rw.Kubeconfig(workspace.DefaultKubeconfig)
+			if rw.DefaultKubeconfig == nil {
+				return fmt.Errorf(
+					"workspaces.%s.default_kubeconfig references missing kubeconfig %q",
+					workspaceName,
+					workspace.DefaultKubeconfig,
+				)
+			}
+		}
+
 		rt.Workspaces[workspaceName] = rw
 	}
 
@@ -336,30 +374,12 @@ func (c *Compiler) compileWorkspaces(rt *RuntimeConfig, cfg *Config) error {
 
 func (c *Compiler) compileDefaults(rt *RuntimeConfig, cfg *Config) error {
 	if cfg.DefaultWorkspace != "" {
-		if _, ok := rt.Workspaces[cfg.DefaultWorkspace]; !ok {
+		rw, ok := rt.Workspaces[cfg.DefaultWorkspace]
+		if !ok {
 			return fmt.Errorf("default_workspace references missing workspace %q", cfg.DefaultWorkspace)
 		}
-	}
 
-	for workspaceName, workspace := range cfg.Workspaces {
-		if workspace == nil {
-			continue
-		}
-
-		if workspace.DefaultContext == "" {
-			continue
-		}
-
-		rw := rt.Workspaces[workspaceName]
-		ref, err := resolveWorkspaceDefaultContext(rt, rw, workspace.DefaultContext)
-		if err != nil {
-			return err
-		}
-
-		rw.DefaultContext = ref
-		ref.Kubeconfig.CurrentContext = ref.Context
-
-		compileNativeKubeconfig(ref.Kubeconfig)
+		rt.DefaultWorkspace = rw
 	}
 
 	return nil
@@ -410,54 +430,24 @@ func indexWorkspaceContexts(rt *RuntimeConfig, rw *RuntimeWorkspace, rkc *Runtim
 	}
 }
 
-func resolveWorkspaceDefaultContext(
-	rt *RuntimeConfig,
-	rw *RuntimeWorkspace,
-	value string,
-) (*RuntimeContextRef, error) {
+func resolveKubeconfigDefaultContext(rkc *RuntimeKubeconfig, value string) error {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return nil, nil
+		return nil
 	}
 
-	// Fully-qualified or kubeconfig-qualified lookup.
-	if ref, ok := rt.Contexts[value]; ok {
-		if ref.Workspace.Name == rw.Name {
-			return ref, nil
-		}
-	}
-
-	// Search by context key or rendered context name within this workspace.
-	var matches []*RuntimeContextRef
-
-	for _, rkc := range rw.Kubeconfigs {
-		for _, ctx := range rkc.Contexts {
-			if ctx.Name == value {
-				matches = append(matches, &RuntimeContextRef{
-					Workspace:  rw,
-					Kubeconfig: rkc,
-					Context:    ctx,
-				})
-			}
-		}
-	}
-
-	switch len(matches) {
-	case 0:
-		return nil, fmt.Errorf(
-			"workspaces.%s.default_context references missing context %q",
-			rw.Name,
-			value,
-		)
-	case 1:
-		return matches[0], nil
-	default:
-		return nil, fmt.Errorf(
-			"workspaces.%s.default_context %q is ambiguous; use kubeconfig/context",
-			rw.Name,
+	ctx, ok := rkc.Contexts[value]
+	if !ok {
+		return fmt.Errorf(
+			"kubeconfigs.%s.default_context references missing context %q",
+			rkc.Name,
 			value,
 		)
 	}
+
+	rkc.DefaultContext = ctx
+	rkc.CurrentContext = ctx
+	return nil
 }
 
 func (c *Compiler) resolvePath(path string) string {

--- a/pkg/config/compile_test.go
+++ b/pkg/config/compile_test.go
@@ -58,3 +58,162 @@ func TestCompileEncryptedTokenOverridesPlaintextToken(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "decrypted-token", runtime.Kubeconfigs["demo"].AuthInfos["user"].AuthInfo.Token)
 }
+
+func TestCompileResolvesKubeconfigCurrentContext(t *testing.T) {
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path:           "/tmp/demo",
+				CurrentContext: "admin",
+				Clusters: map[string]*Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*Context{
+					"admin": {
+						Cluster:  "cluster",
+						AuthInfo: "user",
+					},
+				},
+			},
+		},
+	}
+
+	runtime, err := NewCompiler("").Compile(&cfg)
+	require.NoError(t, err)
+	require.Equal(t, "admin", runtime.Kubeconfigs["demo"].CurrentContext.Name)
+	require.Equal(t, "admin", runtime.Kubeconfigs["demo"].Config.CurrentContext)
+}
+
+func TestCompileFailsWhenKubeconfigCurrentContextIsMissing(t *testing.T) {
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path:           "/tmp/demo",
+				CurrentContext: "missing",
+				Clusters: map[string]*Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*Context{
+					"admin": {
+						Cluster:  "cluster",
+						AuthInfo: "user",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := NewCompiler("").Compile(&cfg)
+	require.EqualError(t, err, "kubeconfigs.demo.current_context references missing context \"missing\"")
+}
+
+func TestCompileKubeconfigDefaultContextOverridesCurrentContext(t *testing.T) {
+	cfg := Config{
+		DefaultWorkspace: "work",
+		Workspaces: map[string]*Workspace{
+			"work": {
+				Kubeconfigs:       []string{"demo"},
+				DefaultKubeconfig: "demo",
+			},
+		},
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path:           "/tmp/demo",
+				CurrentContext: "admin",
+				DefaultContext: "ops",
+				Clusters: map[string]*Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*Context{
+					"admin": {
+						Cluster:  "cluster",
+						AuthInfo: "user",
+					},
+					"ops": {
+						Cluster:  "cluster",
+						AuthInfo: "user",
+					},
+				},
+			},
+		},
+	}
+
+	runtime, err := NewCompiler("").Compile(&cfg)
+	require.NoError(t, err)
+	require.Equal(t, "work", runtime.DefaultWorkspace.Name)
+	require.Equal(t, "demo", runtime.Workspaces["work"].DefaultKubeconfig.Name)
+	require.Equal(t, "ops", runtime.Kubeconfigs["demo"].CurrentContext.Name)
+	require.Equal(t, "ops", runtime.Kubeconfigs["demo"].Config.CurrentContext)
+	require.Equal(t, "ops", runtime.Kubeconfigs["demo"].DefaultContext.Name)
+}
+
+func TestCompileFailsWhenKubeconfigDefaultContextIsMissing(t *testing.T) {
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path:           "/tmp/demo",
+				DefaultContext: "missing",
+				Clusters: map[string]*Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*Context{
+					"admin": {
+						Cluster:  "cluster",
+						AuthInfo: "user",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := NewCompiler("").Compile(&cfg)
+	require.EqualError(t, err, "kubeconfigs.demo.default_context references missing context \"missing\"")
+}
+
+func TestCompileKubeconfigDefaultNamespaceAppliesToContextsWithoutNamespace(t *testing.T) {
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path:             "/tmp/demo",
+				DefaultNamespace: "team-a",
+				Clusters: map[string]*Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*Context{
+					"admin": {
+						Cluster:  "cluster",
+						AuthInfo: "user",
+					},
+					"ops": {
+						Cluster:   "cluster",
+						AuthInfo:  "user",
+						Namespace: "team-b",
+					},
+				},
+			},
+		},
+	}
+
+	runtime, err := NewCompiler("").Compile(&cfg)
+	require.NoError(t, err)
+	require.Equal(t, "team-a", runtime.Kubeconfigs["demo"].DefaultNamespace)
+	require.Equal(t, "team-a", runtime.Kubeconfigs["demo"].Contexts["admin"].Namespace)
+	require.Equal(t, "team-a", runtime.Kubeconfigs["demo"].Config.Contexts["admin"].Namespace)
+	require.Equal(t, "team-b", runtime.Kubeconfigs["demo"].Contexts["ops"].Namespace)
+	require.Equal(t, "team-b", runtime.Kubeconfigs["demo"].Config.Contexts["ops"].Namespace)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,22 +7,24 @@ import (
 type Config struct {
 	Version          string                 `mapstructure:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
 	DefaultWorkspace string                 `mapstructure:"default_workspace,omitempty" json:"default_workspace,omitempty" yaml:"default_workspace,omitempty"`
-	DefaultNamespace string                 `mapstructure:"default_namespace,omitempty" json:"default_namespace,omitempty" yaml:"default_namespace,omitempty"`
 	Workspaces       map[string]*Workspace  `mapstructure:"workspaces,omitempty" json:"workspaces,omitempty" yaml:"workspaces,omitempty"`
 	Kubeconfigs      map[string]*Kubeconfig `mapstructure:"kubeconfigs,omitempty" json:"kubeconfigs,omitempty" yaml:"kubeconfigs,omitempty"`
 }
 
 type Workspace struct {
-	Description      string   `json:"description,omitempty"`
-	Kubeconfigs      []string `json:"kubeconfigs,omitempty"`
-	DefaultContext   string   `json:"default_context,omitempty"`
-	DefaultNamespace string   `json:"default_namespace,omitempty"`
+	Description       string   `mapstructure:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
+	Kubeconfigs       []string `mapstructure:"kubeconfigs,omitempty" json:"kubeconfigs,omitempty" yaml:"kubeconfigs,omitempty"`
+	DefaultKubeconfig string   `mapstructure:"default_kubeconfig,omitempty" json:"default_kubeconfig,omitempty" yaml:"default_kubeconfig,omitempty"`
 }
 
 type Kubeconfig struct {
-	Path      string   `json:"path,omitempty"`
-	Protected bool     `json:"protected,omitempty"`
-	Aliases   []string `json:"aliases,omitempty"`
+	Path           string   `json:"path,omitempty"`
+	Protected      bool     `json:"protected,omitempty"`
+	Aliases        []string `json:"aliases,omitempty"`
+	CurrentContext string   `mapstructure:"current_context,omitempty" json:"current_context,omitempty" yaml:"current_context,omitempty"`
+
+	DefaultContext   string `mapstructure:"default_context,omitempty" json:"default_context,omitempty" yaml:"default_context,omitempty"`
+	DefaultNamespace string `mapstructure:"default_namespace,omitempty" json:"default_namespace,omitempty" yaml:"default_namespace,omitempty"`
 
 	Clusters  map[string]*Cluster  `mapstructure:"clusters,omitempty" json:"clusters,omitempty" yaml:"clusters,omitempty"`
 	AuthInfos map[string]*AuthInfo `mapstructure:"auth_infos,omitempty" json:"auth_infos,omitempty" yaml:"auth_infos,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,3 +27,39 @@ kubeconfigs:
 	require.NoError(t, v.Unmarshal(&cfg))
 	require.Equal(t, "secret-value", cfg.Kubeconfig("demo").AuthInfo("user").EncryptedToken)
 }
+
+func TestViperUnmarshalKubeconfigDefaultContextSnakeCase(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+
+	err := v.ReadConfig(strings.NewReader(`
+version: v1
+kubeconfigs:
+  demo:
+    path: /tmp/demo
+    default_context: admin
+`))
+	require.NoError(t, err)
+
+	var cfg Config
+	require.NoError(t, v.Unmarshal(&cfg))
+	require.Equal(t, "admin", cfg.Kubeconfig("demo").DefaultContext)
+}
+
+func TestViperUnmarshalKubeconfigDefaultNamespaceSnakeCase(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+
+	err := v.ReadConfig(strings.NewReader(`
+version: v1
+kubeconfigs:
+  demo:
+    path: /tmp/demo
+    default_namespace: team-a
+`))
+	require.NoError(t, err)
+
+	var cfg Config
+	require.NoError(t, v.Unmarshal(&cfg))
+	require.Equal(t, "team-a", cfg.Kubeconfig("demo").DefaultNamespace)
+}

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -8,11 +8,9 @@ import (
 type RuntimeConfig struct {
 	Version string
 
-	DefaultWorkspace string
-	DefaultNamespace string
-
-	Workspaces  map[string]*RuntimeWorkspace
-	Kubeconfigs map[string]*RuntimeKubeconfig
+	Workspaces       map[string]*RuntimeWorkspace
+	Kubeconfigs      map[string]*RuntimeKubeconfig
+	DefaultWorkspace *RuntimeWorkspace
 
 	// Lookup indexes for CLI ergonomics.
 	KubeconfigAliases map[string]*RuntimeKubeconfig
@@ -20,14 +18,10 @@ type RuntimeConfig struct {
 }
 
 type RuntimeWorkspace struct {
-	Name string
-
-	Description string
-
-	DefaultNamespace string
-	DefaultContext   *RuntimeContextRef
-
-	Kubeconfigs map[string]*RuntimeKubeconfig
+	Name              string
+	Description       string
+	DefaultKubeconfig *RuntimeKubeconfig
+	Kubeconfigs       map[string]*RuntimeKubeconfig
 }
 
 type RuntimeKubeconfig struct {
@@ -41,7 +35,9 @@ type RuntimeKubeconfig struct {
 	AuthInfos map[string]*RuntimeAuthInfo
 	Contexts  map[string]*RuntimeContext
 
-	CurrentContext *RuntimeContext
+	CurrentContext   *RuntimeContext
+	DefaultContext   *RuntimeContext
+	DefaultNamespace string
 
 	Config *api.Config
 }


### PR DESCRIPTION
Add support for workspace.default_kubeconfig and kubeconfig.default_context. Kubeconfig.default_context overrides current_context if both are set. Kubeconfig.default_namespace is now applied to contexts without a namespace. Update describe_workspace output to show default kubeconfig and context. Includes tests for new config fields and resolution logic.