### PR TITLE
refactor(config): remove global baseDir, resolve paths per config 

### DIFF
--- a/cmd/kubecfg/decrypt_flags.go
+++ b/cmd/kubecfg/decrypt_flags.go
@@ -24,7 +24,7 @@ func newCompilerWithOptionalDecryptor(cfg *config.Config, identityFile string) (
 		compilerOpts = append(compilerOpts, config.WithDecryptor(decryptor))
 	}
 
-	return config.NewCompiler(baseDir, compilerOpts...), nil
+	return config.NewCompiler(compilerOpts...), nil
 }
 
 func loadAgeDecryptor(identityFile string) (*decrypt.AgeDecryptor, error) {

--- a/cmd/kubecfg/describe_workspace_test.go
+++ b/cmd/kubecfg/describe_workspace_test.go
@@ -11,14 +11,11 @@ import (
 
 func TestRunDescribeWorkspaceCmdRendersDefaultKubeconfig(t *testing.T) {
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 	})
 
 	cfg = newDescribeWorkspaceTestConfig()
-	baseDir = "/tmp"
 
 	var stdout bytes.Buffer
 	err := runDescribeWorkspaceCmd([]string{"work"}, "", &stdout)
@@ -65,15 +62,12 @@ func newDescribeWorkspaceTestConfig() config.Config {
 
 func TestRunDescribeWorkspaceCmdRendersEmptyDefaultKubeconfigWhenUnset(t *testing.T) {
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 	})
 
 	cfg = newDescribeWorkspaceTestConfig()
 	cfg.Workspaces["work"].DefaultKubeconfig = ""
-	baseDir = "/tmp"
 
 	var stdout bytes.Buffer
 	err := runDescribeWorkspaceCmd([]string{"work"}, "", &stdout)

--- a/cmd/kubecfg/login.go
+++ b/cmd/kubecfg/login.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"time"
 
 	"github.com/amimof/kubecfg/pkg/command"
@@ -13,8 +12,8 @@ import (
 )
 
 var (
-	loginStdout io.Writer = os.Stdout
-	loginStderr io.Writer = os.Stderr
+	loginStdout *bytes.Buffer = &bytes.Buffer{}
+	loginStderr *bytes.Buffer = &bytes.Buffer{}
 )
 
 func newLoginCmd() *cobra.Command {

--- a/cmd/kubecfg/login_test.go
+++ b/cmd/kubecfg/login_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/amimof/kubecfg/pkg/config"
 	"github.com/stretchr/testify/require"
@@ -18,18 +19,15 @@ func TestRunLoginCmdStreamsSubprocessOutputAndImportsAuthInfo(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), "target-kubeconfig.yaml")
 
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	originalStdout := loginStdout
 	originalStderr := loginStderr
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 		loginStdout = originalStdout
 		loginStderr = originalStderr
 	})
 
 	cfg = newLoginCommandTestConfig(targetPath)
-	baseDir = filepath.Dir(targetPath)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -56,22 +54,19 @@ func TestRunLoginCmdDoesNotMutateCredentialSourceEnv(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), "target-kubeconfig.yaml")
 
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	originalStdout := loginStdout
 	originalStderr := loginStderr
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 		loginStdout = originalStdout
 		loginStderr = originalStderr
 	})
 
 	cfg = newLoginCommandTestConfig(targetPath)
-	baseDir = filepath.Dir(targetPath)
-	loginStdout = io.Discard
-	loginStderr = io.Discard
+	loginStdout = &bytes.Buffer{}
+	loginStderr = &bytes.Buffer{}
 
-	compiler := config.NewCompiler(baseDir)
+	compiler := config.NewCompiler()
 	runtime, err := compiler.Compile(&cfg)
 	require.NoError(t, err)
 
@@ -90,20 +85,17 @@ func TestRunLoginCmdDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 	identityFile, encryptedToken := writeAgeIdentityAndEncryptedToken(t, "login-token")
 
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	originalStdout := loginStdout
 	originalStderr := loginStderr
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 		loginStdout = originalStdout
 		loginStderr = originalStderr
 	})
 
 	cfg = newLoginCommandEncryptedTestConfig(targetPath, encryptedToken)
-	baseDir = filepath.Dir(targetPath)
-	loginStdout = io.Discard
-	loginStderr = io.Discard
+	loginStdout = &bytes.Buffer{}
+	loginStderr = &bytes.Buffer{}
 
 	err := runLoginCmd("work", "vgr", "ctx1", identityFile)
 	require.NoError(t, err)
@@ -164,6 +156,7 @@ func TestHelperProcessLoginCommand(t *testing.T) {
 func newLoginCommandTestConfig(targetPath string) config.Config {
 	return config.Config{
 		Version: "v1",
+		BaseDir: filepath.Dir(targetPath),
 		Workspaces: map[string]*config.Workspace{
 			"work": {
 				Kubeconfigs: []string{"vgr"},
@@ -200,4 +193,51 @@ func newLoginCommandEncryptedTestConfig(targetPath, encryptedToken string) confi
 	cfg := newLoginCommandTestConfig(targetPath)
 	cfg.Kubeconfigs["vgr"].AuthInfos["login-user"].EncryptedToken = encryptedToken
 	return cfg
+}
+
+func TestRunUseCmdWritesResolvedRuntimePath(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "target-kubeconfig.yaml")
+
+	originalCfg := cfg
+	t.Cleanup(func() {
+		cfg = originalCfg
+	})
+
+	cfg = newUsePathResolutionTestConfig(targetDir)
+
+	err := runUseCmd("work", "vgr", true, "", time.Second)
+	require.NoError(t, err)
+
+	_, err = os.Stat(targetPath)
+	require.NoError(t, err)
+}
+
+func newUsePathResolutionTestConfig(targetDir string) config.Config {
+	return config.Config{
+		Version: "v1",
+		BaseDir: targetDir,
+		Workspaces: map[string]*config.Workspace{
+			"work": {
+				Kubeconfigs: []string{"vgr"},
+			},
+		},
+		Kubeconfigs: map[string]*config.Kubeconfig{
+			"vgr": {
+				Path: "@/target-kubeconfig.yaml",
+				Clusters: map[string]*config.Cluster{
+					"cluster": {Server: "https://example.com"},
+				},
+				AuthInfos: map[string]*config.AuthInfo{
+					"user": {},
+				},
+				Contexts: map[string]*config.Context{
+					"context": {
+						Cluster:  "cluster",
+						AuthInfo: "user",
+					},
+				},
+			},
+		},
+	}
 }

--- a/cmd/kubecfg/main.go
+++ b/cmd/kubecfg/main.go
@@ -37,7 +37,6 @@ var (
 
 	logLevel   string
 	configFile string
-	baseDir    string
 
 	// Root command
 	rootCmd = cobra.Command{
@@ -56,7 +55,6 @@ func init() {
 func initConfig() {
 	viper.SetConfigFile(configFile)
 	viper.SetConfigType("yaml")
-	// viper.SetOptions(viper.WithEncoderRegistry)
 }
 
 func withConfig(run func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
@@ -118,11 +116,9 @@ func main() {
 		logrus.Fatalf("home directory cannot be determined: %v", err)
 	}
 	defaultConfigPath := filepath.Join(home, ".config", "kubecfg.yaml")
-	defaultBaseDir := filepath.Join(home, ".kube")
 
 	// Setup flags
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", defaultConfigPath, "config file")
-	rootCmd.PersistentFlags().StringVarP(&baseDir, "base-dir", "b", defaultBaseDir, "kubeconfig base directory")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "number for the log level verbosity (debug, info, warn, error, fatal, panic)")
 
 	rootCmd.AddCommand(newVersionCmd())

--- a/cmd/kubecfg/use.go
+++ b/cmd/kubecfg/use.go
@@ -70,7 +70,7 @@ func writeKubeconfig(path string, kubeconfig api.Config) error {
 }
 
 // setConfig creates a new symlink to a kubeconfigfile overwriting any existing one
-func setConfig(name string) error {
+func setConfig(baseDir, name string) error {
 	dst := path.Join(baseDir, "config")
 	// Remove existing symlink to config so we don't run into an error
 	if _, err := os.Stat(dst); !os.IsNotExist(err) {
@@ -131,7 +131,7 @@ func runUseCmd(workspaceName, kubeconfigName string, skipLogin bool, identityFil
 		return err
 	}
 
-	if err := setConfig(rk.Path); err != nil {
+	if err := setConfig(runtime.BaseDir, rk.Path); err != nil {
 		return err
 	}
 
@@ -173,7 +173,7 @@ func runUseCmdFzf(workspaceName string, skipLogin bool, identityFile string, wai
 	if err := writeKubeconfig(rk.Path, *rk.Config); err != nil {
 		return err
 	}
-	if err := setConfig(rk.Path); err != nil {
+	if err := setConfig(runtime.BaseDir, rk.Path); err != nil {
 		return err
 	}
 	fmt.Printf("Using kubeconfig: %s/%s\n", workspace, selected)

--- a/cmd/kubecfg/use.go
+++ b/cmd/kubecfg/use.go
@@ -13,7 +13,6 @@ import (
 	"github.com/amimof/kubecfg/pkg/command"
 	"github.com/amimof/kubecfg/pkg/config"
 	"github.com/amimof/kubecfg/pkg/service"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -180,7 +179,7 @@ func runUseCmdFzf(workspaceName string, skipLogin bool, identityFile string, wai
 	return nil
 }
 
-func runLogin(rk *config.RuntimeKubeconfig, waitTimeout time.Duration) error {
+func runLogin(rk *config.RuntimeKubeconfig, waitTimeout time.Duration) (err error) {
 	for name, ctx := range rk.Contexts {
 
 		aui := rk.AuthInfo(ctx.AuthInfo.Name)
@@ -191,7 +190,7 @@ func runLogin(rk *config.RuntimeKubeconfig, waitTimeout time.Duration) error {
 
 			dash, err := cmdutil.NewDashboard([]string{name}, cmdutil.WithHeader("Running login flow for"))
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			go dash.Loop(cmdCtx)
@@ -203,12 +202,15 @@ func runLogin(rk *config.RuntimeKubeconfig, waitTimeout time.Duration) error {
 				runner := command.NewExecCommandRunner()
 				loginService := service.LoginService{Runner: runner, Stdout: loginStdout, Stderr: loginStderr}
 
-				newAuth, err := loginService.Login(cmdCtx, aui)
-				if err != nil {
-					escapedMsg := strings.ReplaceAll(loginStdout.String(), "\n", "n")
-					dash.FailMsg(0, "Login command returned an error")
+				newAuth, loginErr := loginService.Login(cmdCtx, aui)
+
+				time.Sleep(1 * time.Second)
+
+				if loginErr != nil {
+					escapedMsg := strings.ReplaceAll(loginStderr.String(), "\n", "n")
 					dash.SetPhase(0, escapedMsg)
-					logrus.Fatal(err)
+					dash.FailMsg(0, "Login command returned an error")
+					err = fmt.Errorf("%v: %s", loginErr, escapedMsg)
 				}
 
 				rk.Config.AuthInfos[ctx.AuthInfo.Name] = newAuth
@@ -218,10 +220,14 @@ func runLogin(rk *config.RuntimeKubeconfig, waitTimeout time.Duration) error {
 
 			dash.WaitAnd(cancel)
 
+			if err != nil {
+				return err
+			}
+
 		}
 	}
 
-	return nil
+	return err
 }
 
 func pickContext(rc *config.RuntimeConfig, workspaceName string) (string, string, error) {

--- a/cmd/kubecfg/use.go
+++ b/cmd/kubecfg/use.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/amimof/kubecfg/pkg/cmdutil"
 	"github.com/amimof/kubecfg/pkg/command"
 	"github.com/amimof/kubecfg/pkg/config"
 	"github.com/amimof/kubecfg/pkg/service"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -29,6 +31,7 @@ func newUseCmd() *cobra.Command {
 		workspaceName string
 		skipLogin     bool
 		identityFile  string
+		waitTimeout   time.Duration
 	)
 
 	cmd := &cobra.Command{
@@ -41,15 +44,16 @@ func newUseCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return runUseCmdFzf(workspaceName, skipLogin, identityFile)
+				return runUseCmdFzf(workspaceName, skipLogin, identityFile, waitTimeout)
 			}
-			return runUseCmd(workspaceName, args[0], skipLogin, identityFile)
+			return runUseCmd(workspaceName, args[0], skipLogin, identityFile, waitTimeout)
 		}),
 	}
 
 	cmd.PersistentFlags().StringVarP(&workspaceName, "workspace", "w", "", "Workspace")
 	cmd.PersistentFlags().StringVar(&identityFile, "identity-file", "", "Age identity used to decrypt fields in configuration")
 	cmd.PersistentFlags().BoolVar(&skipLogin, "skip-login", false, "Skip execution of login flow prior to kubeconfig rendering")
+	cmd.PersistentFlags().DurationVar(&waitTimeout, "timeout", time.Second*30, "How long in seconds to wait for login opearation to finish before giving up")
 
 	return cmd
 }
@@ -79,7 +83,7 @@ func setConfig(name string) error {
 	return os.Symlink(name, path.Join(baseDir, "config"))
 }
 
-func runUseCmd(workspaceName, kubeconfigName string, skipLogin bool, identityFile string) error {
+func runUseCmd(workspaceName, kubeconfigName string, skipLogin bool, identityFile string, waitTimeout time.Duration) error {
 	compiler, err := newCompilerWithOptionalDecryptor(&cfg, identityFile)
 	if err != nil {
 		return err
@@ -118,7 +122,7 @@ func runUseCmd(workspaceName, kubeconfigName string, skipLogin bool, identityFil
 	}
 
 	if !skipLogin {
-		if err := runLogin(rk); err != nil {
+		if err := runLogin(rk, waitTimeout); err != nil {
 			return err
 		}
 	}
@@ -135,7 +139,7 @@ func runUseCmd(workspaceName, kubeconfigName string, skipLogin bool, identityFil
 	return nil
 }
 
-func runUseCmdFzf(workspaceName string, skipLogin bool, identityFile string) error {
+func runUseCmdFzf(workspaceName string, skipLogin bool, identityFile string, waitTimeout time.Duration) error {
 	compiler, err := newCompilerWithOptionalDecryptor(&cfg, identityFile)
 	if err != nil {
 		return err
@@ -161,7 +165,7 @@ func runUseCmdFzf(workspaceName string, skipLogin bool, identityFile string) err
 	}
 
 	if !skipLogin {
-		if err := runLogin(rk); err != nil {
+		if err := runLogin(rk, waitTimeout); err != nil {
 			return err
 		}
 	}
@@ -176,23 +180,44 @@ func runUseCmdFzf(workspaceName string, skipLogin bool, identityFile string) err
 	return nil
 }
 
-func runLogin(rk *config.RuntimeKubeconfig) error {
+func runLogin(rk *config.RuntimeKubeconfig, waitTimeout time.Duration) error {
 	for name, ctx := range rk.Contexts {
 
 		aui := rk.AuthInfo(ctx.AuthInfo.Name)
 
 		if aui.CredentialSource != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			cmdCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			runner := command.NewExecCommandRunner()
-			loginService := service.LoginService{Runner: runner, Stdout: loginStdout, Stderr: loginStderr}
-			newAuth, err := loginService.Login(ctx, aui)
+			dash, err := cmdutil.NewDashboard([]string{name}, cmdutil.WithHeader("Running login flow for"))
 			if err != nil {
-				return err
+				logrus.Fatal(err)
 			}
 
-			rk.Config.AuthInfos[name] = newAuth
+			go dash.Loop(cmdCtx)
+
+			// Fire off start operations concurrently
+			go func() {
+				dash.FailAfterMsg(0, waitTimeout, "timeout reached")
+
+				runner := command.NewExecCommandRunner()
+				loginService := service.LoginService{Runner: runner, Stdout: loginStdout, Stderr: loginStderr}
+
+				newAuth, err := loginService.Login(cmdCtx, aui)
+				if err != nil {
+					escapedMsg := strings.ReplaceAll(loginStdout.String(), "\n", "n")
+					dash.FailMsg(0, "Login command returned an error")
+					dash.SetPhase(0, escapedMsg)
+					logrus.Fatal(err)
+				}
+
+				rk.Config.AuthInfos[ctx.AuthInfo.Name] = newAuth
+
+				dash.DoneMsg(0, fmt.Sprintf("Successfully logged in user %s", ctx.AuthInfo.Name))
+			}()
+
+			dash.WaitAnd(cancel)
+
 		}
 	}
 

--- a/cmd/kubecfg/use_test.go
+++ b/cmd/kubecfg/use_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"filippo.io/age"
 	"github.com/amimof/kubecfg/pkg/config"
@@ -107,23 +108,20 @@ func TestRunUseCmdFzfNoSelectionIsNoOp(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), "target-kubeconfig.yaml")
 
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	originalFzfRun := fzfRun
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 		fzfRun = originalFzfRun
 	})
 
 	cfg = newUseCommandTestConfig(targetPath)
-	baseDir = filepath.Dir(targetPath)
 	fzfRun = func(options *fzf.Options) (int, error) {
 		for range options.Input {
 		}
 		return fzf.ExitNoMatch, nil
 	}
 
-	err := runUseCmdFzf("", false, "")
+	err := runUseCmdFzf("", false, "", time.Second)
 	require.NoError(t, err)
 
 	_, err = os.Stat(targetPath)
@@ -138,16 +136,13 @@ func TestRunUseCmdFzfUpdatesActiveConfigSymlink(t *testing.T) {
 	targetPath := filepath.Join(tmpDir, "target-kubeconfig.yaml")
 
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	originalFzfRun := fzfRun
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 		fzfRun = originalFzfRun
 	})
 
 	cfg = newUseCommandTestConfig(targetPath)
-	baseDir = tmpDir
 	fzfRun = func(options *fzf.Options) (int, error) {
 		for range options.Input {
 		}
@@ -155,10 +150,10 @@ func TestRunUseCmdFzfUpdatesActiveConfigSymlink(t *testing.T) {
 		return fzf.ExitOk, nil
 	}
 
-	err := runUseCmdFzf("", false, "")
+	err := runUseCmdFzf("", false, "", time.Second)
 	require.NoError(t, err)
 
-	linkPath := filepath.Join(baseDir, "config")
+	linkPath := filepath.Join(tmpDir, "config")
 	linkedTo, err := os.Readlink(linkPath)
 	require.NoError(t, err)
 	require.Equal(t, targetPath, linkedTo)
@@ -171,16 +166,13 @@ func TestRunUseCmdDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 	identityFile, encryptedToken := writeAgeIdentityAndEncryptedToken(t, "command-token")
 
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 	})
 
 	cfg = newEncryptedUseCommandTestConfig(targetPath, encryptedToken)
-	baseDir = filepath.Dir(targetPath)
 
-	err := runUseCmd("work", "vgr", true, identityFile)
+	err := runUseCmd("work", "vgr", true, identityFile, time.Second)
 	require.NoError(t, err)
 
 	contents, err := os.ReadFile(targetPath)
@@ -198,16 +190,13 @@ func TestRunUseCmdFzfDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 	identityFile, encryptedToken := writeAgeIdentityAndEncryptedToken(t, "fzf-token")
 
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	originalFzfRun := fzfRun
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 		fzfRun = originalFzfRun
 	})
 
 	cfg = newEncryptedUseCommandTestConfig(targetPath, encryptedToken)
-	baseDir = tmpDir
 	fzfRun = func(options *fzf.Options) (int, error) {
 		for range options.Input {
 		}
@@ -215,7 +204,7 @@ func TestRunUseCmdFzfDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 		return fzf.ExitOk, nil
 	}
 
-	err := runUseCmdFzf("", true, identityFile)
+	err := runUseCmdFzf("", true, identityFile, time.Second)
 	require.NoError(t, err)
 
 	contents, err := os.ReadFile(targetPath)
@@ -279,6 +268,7 @@ func newWriteKubeconfigTestConfig() api.Config {
 func newUseCommandTestConfig(targetPath string) config.Config {
 	return config.Config{
 		Version: "v1",
+		BaseDir: filepath.Dir(targetPath),
 		Workspaces: map[string]*config.Workspace{
 			"work": {
 				Kubeconfigs: []string{"vgr"},

--- a/cmd/kubecfg/workspaces.go
+++ b/cmd/kubecfg/workspaces.go
@@ -28,7 +28,7 @@ func newWorkspacesCmd() *cobra.Command {
 }
 
 func runWorkspacesCmd(stdout io.Writer) error {
-	compiler := config.NewCompiler(baseDir)
+	compiler := config.NewCompiler()
 
 	runtime, err := compiler.Compile(&cfg)
 	if err != nil {

--- a/cmd/kubecfg/workspaces_test.go
+++ b/cmd/kubecfg/workspaces_test.go
@@ -11,14 +11,11 @@ import (
 
 func TestRunWorkspacesCmdPrintsHeaderedTable(t *testing.T) {
 	originalCfg := cfg
-	originalBaseDir := baseDir
 	t.Cleanup(func() {
 		cfg = originalCfg
-		baseDir = originalBaseDir
 	})
 
 	cfg = newWorkspacesCommandTestConfig()
-	baseDir = "/tmp"
 
 	var stdout bytes.Buffer
 	err := runWorkspacesCmd(&stdout)

--- a/pkg/cmdutil/dashboard.go
+++ b/pkg/cmdutil/dashboard.go
@@ -19,7 +19,7 @@ type Color string
 type Field int
 
 const (
-	FieldPhase Field = iota
+	FieldError Field = iota
 	FieldNode
 	FieldPid
 	FieldID
@@ -31,14 +31,11 @@ const (
 // Detail lines are suppressed when the entry is in a terminal state (failed or
 // done) so that only the status line remains visible.
 var fieldTemplate = map[Field]string{
-	FieldPhase:  `{{- if and (not .Container.Failed) (not .Container.Done) }}  Phase: {{ if eq .Container.Phase "Running" }}{{ .Container.Phase | FgGreen }}{{else}}{{ .Container.Phase | FgYellow }}{{end}}{{- end}}`,
-	FieldNode:   `  Node: {{ .Container.Node }}`,
-	FieldPid:    `  Pid: {{ .Container.Pid }}`,
-	FieldReason: `{{- if and (not .Container.Failed) (not .Container.Done) }}  Error: {{ .Container.Reason | FgBlue }}{{- end}}`,
+	FieldError: `{{- if ne .Container.Error "" }}  {{ "Error:" | FgRed }} {{ .Container.Error }} {{- end}}`,
 }
 
 // defaultFields is the ordered set of fields shown when WithFields is not called.
-var defaultFields = []Field{FieldPhase, FieldNode, FieldPid, FieldReason}
+var defaultFields = []Field{FieldError, FieldNode, FieldPid, FieldReason}
 
 type Option func(*Dashboard)
 
@@ -136,15 +133,7 @@ func (d *Dashboard) AddTask(t *config.Config) int {
 func (d *Dashboard) SetTask(idx int, t *config.Config) {
 	d.Update(idx, func(s *ServiceState) {
 		s.config = t
-		s.container.SetMetadata(map[string]any{
-			// "Name":   t.GetMeta().GetName(),
-			// "Phase":  t.GetStatus().GetPhase().GetValue(),
-			// "Node":   t.GetStatus().GetNode().GetValue(),
-			// "Pid":    t.GetStatus().GetPid().GetValue(),
-			// "ID":     t.GetStatus().GetId().GetValue(),
-			// "Image":  t.GetConfig().GetImage(),
-			// "Reason": t.GetStatus().GetReason(),
-		})
+		s.container.SetMetadata(map[string]any{})
 	})
 }
 
@@ -185,6 +174,12 @@ func (d *Dashboard) FailMsg(idx int, msg string) {
 		s.Done = true
 		s.Failed = true
 		s.FailedMsg = msg
+	})
+}
+
+func (d *Dashboard) SetPhase(idx int, msg string) {
+	d.Update(idx, func(s *ServiceState) {
+		s.container.UpdateMetadata("Error", msg)
 	})
 }
 
@@ -306,12 +301,7 @@ func NewDashboard(names []string, opts ...Option) (*Dashboard, error) {
 			"Failed":    false,
 			"FailedMsg": "",
 			"Name":      n,
-			"Phase":     "",
-			"Node":      "",
-			"Pid":       "",
-			"ID":        "",
-			"Image":     "",
-			"Reason":    "",
+			"Error":     "",
 		}
 
 		// Status line is always present.

--- a/pkg/cmdutil/dashboard.go
+++ b/pkg/cmdutil/dashboard.go
@@ -13,6 +13,8 @@ import (
 	"github.com/amimof/kubecfg/pkg/config"
 )
 
+const defaultDashboardWidth = 80
+
 type Color string
 
 // Field identifies a detail line that can be shown per task entry in the dashboard.
@@ -252,17 +254,6 @@ func (d *Dashboard) IsDone() bool {
 
 // NewDashboard creates the dashboard with one ServiceState per name.
 func NewDashboard(names []string, opts ...Option) (*Dashboard, error) {
-	var width, height int
-	// Get width of terminal
-	if term.IsTerminal(0) {
-		w, h, err := term.GetSize(0)
-		if err != nil {
-			return nil, err
-		}
-		width = w
-		height = h
-	}
-
 	app := NewApp(os.Stdout,
 		map[string]any{},
 	)
@@ -279,6 +270,11 @@ func NewDashboard(names []string, opts ...Option) (*Dashboard, error) {
 
 	for _, opt := range opts {
 		opt(d)
+	}
+
+	width, height, err := dashboardDimensions(d.app.Writer)
+	if err != nil {
+		return nil, err
 	}
 
 	// Resolve effective field set: nil means "all fields" (default behaviour).
@@ -333,4 +329,21 @@ func NewDashboard(names []string, opts ...Option) (*Dashboard, error) {
 	d.services = svcs
 
 	return d, nil
+}
+
+func dashboardDimensions(w io.Writer) (int, int, error) {
+	file, ok := w.(*os.File)
+	if !ok || !term.IsTerminal(int(file.Fd())) {
+		return defaultDashboardWidth, 0, nil
+	}
+
+	width, height, err := term.GetSize(int(file.Fd()))
+	if err != nil {
+		return 0, 0, err
+	}
+	if width <= 0 {
+		width = defaultDashboardWidth
+	}
+
+	return width, height, nil
 }

--- a/pkg/cmdutil/renderer.go
+++ b/pkg/cmdutil/renderer.go
@@ -194,7 +194,7 @@ func (c *Container) RenderLines(data Data, frameIdx int) []string {
 			continue
 		}
 		padded := fmt.Sprintf("  %s  ", r.text)
-		if len(padded) >= c.Dimensions[0] {
+		if visibleLength(padded) > c.Dimensions[0] {
 			padded = truncateWithEllipsis(padded, c.Dimensions[0])
 		}
 		lines = append(lines, c.applyBgColor(padded, c.Dimensions[0]))
@@ -507,7 +507,7 @@ func truncateToWidth(s string, width int) string {
 
 // visibleLength returns the visible character count (excluding ANSI codes)
 func visibleLength(s string) int {
-	return len(stripANSI(s))
+	return utf8.RuneCountInString(stripANSI(s))
 }
 
 // padRight pads a string to a fixed width (accounting for ANSI codes)

--- a/pkg/cmdutil/renderer_test.go
+++ b/pkg/cmdutil/renderer_test.go
@@ -1,0 +1,95 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestContainerRenderLinesTruncatesLongPlainText(t *testing.T) {
+	container := NewContainer(nil,
+		NewElement(`{{ .Value }}`),
+	).WithLayout(Layout{Dimensions: [2]int{10, 0}})
+
+	lines := container.RenderLines(Data{"Value": "abcdefghijklmnopqrstuvwxyz"}, 0)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 rendered line, got %d", len(lines))
+	}
+
+	got := stripANSI(lines[0])
+	if visibleLength(got) != 10 {
+		t.Fatalf("expected visible width 10, got %d (%q)", visibleLength(got), got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Fatalf("expected ellipsis in %q", got)
+	}
+	if got != "  abcde…  " {
+		t.Fatalf("unexpected truncation result %q", got)
+	}
+}
+
+func TestContainerRenderLinesTruncatesAnsiTextByVisibleWidth(t *testing.T) {
+	oldNoColor := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() {
+		color.NoColor = oldNoColor
+	})
+
+	container := NewContainer(nil,
+		NewElement(`{{ .Value | FgRed }}`),
+	).WithLayout(Layout{Dimensions: [2]int{10, 0}})
+
+	lines := container.RenderLines(Data{"Value": "abcdefghijklmnopqrstuvwxyz"}, 0)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 rendered line, got %d", len(lines))
+	}
+
+	got := lines[0]
+	if visibleLength(got) != 10 {
+		t.Fatalf("expected visible width 10, got %d (%q)", visibleLength(got), stripANSI(got))
+	}
+	if !strings.Contains(stripANSI(got), "…") {
+		t.Fatalf("expected ellipsis in %q", stripANSI(got))
+	}
+	if !strings.Contains(got, "\x1b[") {
+		t.Fatalf("expected ANSI escape sequences in %q", got)
+	}
+	if stripANSI(got) != "  abcde…  " {
+		t.Fatalf("unexpected truncation result %q", stripANSI(got))
+	}
+}
+
+func TestContainerRenderLinesTruncatesMultibyteTextByRunes(t *testing.T) {
+	container := NewContainer(nil,
+		NewElement(`{{ .Value }}`),
+	).WithLayout(Layout{Dimensions: [2]int{8, 0}})
+
+	lines := container.RenderLines(Data{"Value": "世界世界世界世界"}, 0)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 rendered line, got %d", len(lines))
+	}
+
+	got := stripANSI(lines[0])
+	if visibleLength(got) != 8 {
+		t.Fatalf("expected visible width 8, got %d (%q)", visibleLength(got), got)
+	}
+	if got != "  世界世…  " {
+		t.Fatalf("unexpected truncation result %q", got)
+	}
+}
+
+func TestNewDashboardUsesDefaultWidthWhenWriterIsNotATerminal(t *testing.T) {
+	dash, err := NewDashboard([]string{"service"}, WithWriter(&strings.Builder{}))
+	if err != nil {
+		t.Fatalf("NewDashboard returned error: %v", err)
+	}
+
+	if len(dash.services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(dash.services))
+	}
+
+	if got := dash.services[0].container.Dimensions[0]; got != defaultDashboardWidth {
+		t.Fatalf("expected fallback width %d, got %d", defaultDashboardWidth, got)
+	}
+}

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -39,6 +39,7 @@ func (c *Compiler) Compile(cfg *Config) (*RuntimeConfig, error) {
 
 	rt := &RuntimeConfig{
 		Version: cfg.Version,
+		BaseDir: cfg.BaseDir,
 
 		Workspaces:        make(map[string]*RuntimeWorkspace),
 		Kubeconfigs:       make(map[string]*RuntimeKubeconfig),

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 )
 
 type Compiler struct {
-	BaseDir   string
 	Decryptor SecretDecryptor
 }
 
@@ -21,10 +21,8 @@ func WithDecryptor(d SecretDecryptor) CompilerOption {
 	}
 }
 
-func NewCompiler(baseDir string, opts ...CompilerOption) *Compiler {
-	c := &Compiler{
-		BaseDir: baseDir,
-	}
+func NewCompiler(opts ...CompilerOption) *Compiler {
+	c := &Compiler{}
 
 	for _, opt := range opts {
 		opt(c)
@@ -70,7 +68,7 @@ func (c *Compiler) compileKubeconfigs(rt *RuntimeConfig, cfg *Config) error {
 
 		rkc := &RuntimeKubeconfig{
 			Name:             kubeconfigName,
-			Path:             c.resolvePath(kubeconfig.Path),
+			Path:             c.resolvePath(rt, kubeconfig.Path),
 			Protected:        kubeconfig.Protected,
 			Aliases:          append([]string(nil), kubeconfig.Aliases...),
 			DefaultNamespace: strings.TrimSpace(kubeconfig.DefaultNamespace),
@@ -383,6 +381,15 @@ func (c *Compiler) compileDefaults(rt *RuntimeConfig, cfg *Config) error {
 		rt.DefaultWorkspace = rw
 	}
 
+	if rt.BaseDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		defaultBaseDir := filepath.Join(home, ".kube")
+		rt.BaseDir = defaultBaseDir
+	}
+
 	return nil
 }
 
@@ -451,7 +458,7 @@ func resolveKubeconfigDefaultContext(rkc *RuntimeKubeconfig, value string) error
 	return nil
 }
 
-func (c *Compiler) resolvePath(path string) string {
+func (c *Compiler) resolvePath(rt *RuntimeConfig, path string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return ""
@@ -461,11 +468,11 @@ func (c *Compiler) resolvePath(path string) string {
 		relative := after
 		relative = strings.TrimPrefix(relative, "/")
 
-		if c.BaseDir == "" {
+		if rt.BaseDir == "" {
 			return relative
 		}
 
-		return filepath.Join(c.BaseDir, relative)
+		return filepath.Join(rt.BaseDir, relative)
 	}
 
 	return path

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -45,6 +45,15 @@ func (c *Compiler) Compile(cfg *Config) (*RuntimeConfig, error) {
 		Contexts:          make(map[string]*RuntimeContextRef),
 	}
 
+	if rt.BaseDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		defaultBaseDir := filepath.Join(home, ".kube")
+		rt.BaseDir = defaultBaseDir
+	}
+
 	if err := c.compileKubeconfigs(rt, cfg); err != nil {
 		return nil, err
 	}
@@ -379,15 +388,6 @@ func (c *Compiler) compileDefaults(rt *RuntimeConfig, cfg *Config) error {
 		}
 
 		rt.DefaultWorkspace = rw
-	}
-
-	if rt.BaseDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return err
-		}
-		defaultBaseDir := filepath.Join(home, ".kube")
-		rt.BaseDir = defaultBaseDir
 	}
 
 	return nil

--- a/pkg/config/compile_test.go
+++ b/pkg/config/compile_test.go
@@ -20,7 +20,7 @@ func TestCompileFailsWhenEncryptedFieldsExistWithoutDecryptor(t *testing.T) {
 		},
 	}
 
-	_, err := NewCompiler("").Compile(&cfg)
+	_, err := NewCompiler().Compile(&cfg)
 	require.EqualError(t, err, "authinfo \"user\" contains encrypted fields; provide --identity-file or a passphrase")
 }
 
@@ -54,7 +54,7 @@ func TestCompileEncryptedTokenOverridesPlaintextToken(t *testing.T) {
 		},
 	}
 
-	runtime, err := NewCompiler("", WithDecryptor(decryptor)).Compile(&cfg)
+	runtime, err := NewCompiler(WithDecryptor(decryptor)).Compile(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, "decrypted-token", runtime.Kubeconfigs["demo"].AuthInfos["user"].AuthInfo.Token)
 }
@@ -81,7 +81,7 @@ func TestCompileResolvesKubeconfigCurrentContext(t *testing.T) {
 		},
 	}
 
-	runtime, err := NewCompiler("").Compile(&cfg)
+	runtime, err := NewCompiler().Compile(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, "admin", runtime.Kubeconfigs["demo"].CurrentContext.Name)
 	require.Equal(t, "admin", runtime.Kubeconfigs["demo"].Config.CurrentContext)
@@ -109,7 +109,7 @@ func TestCompileFailsWhenKubeconfigCurrentContextIsMissing(t *testing.T) {
 		},
 	}
 
-	_, err := NewCompiler("").Compile(&cfg)
+	_, err := NewCompiler().Compile(&cfg)
 	require.EqualError(t, err, "kubeconfigs.demo.current_context references missing context \"missing\"")
 }
 
@@ -147,7 +147,7 @@ func TestCompileKubeconfigDefaultContextOverridesCurrentContext(t *testing.T) {
 		},
 	}
 
-	runtime, err := NewCompiler("").Compile(&cfg)
+	runtime, err := NewCompiler().Compile(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, "work", runtime.DefaultWorkspace.Name)
 	require.Equal(t, "demo", runtime.Workspaces["work"].DefaultKubeconfig.Name)
@@ -178,7 +178,7 @@ func TestCompileFailsWhenKubeconfigDefaultContextIsMissing(t *testing.T) {
 		},
 	}
 
-	_, err := NewCompiler("").Compile(&cfg)
+	_, err := NewCompiler().Compile(&cfg)
 	require.EqualError(t, err, "kubeconfigs.demo.default_context references missing context \"missing\"")
 }
 
@@ -209,11 +209,26 @@ func TestCompileKubeconfigDefaultNamespaceAppliesToContextsWithoutNamespace(t *t
 		},
 	}
 
-	runtime, err := NewCompiler("").Compile(&cfg)
+	runtime, err := NewCompiler().Compile(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, "team-a", runtime.Kubeconfigs["demo"].DefaultNamespace)
 	require.Equal(t, "team-a", runtime.Kubeconfigs["demo"].Contexts["admin"].Namespace)
 	require.Equal(t, "team-a", runtime.Kubeconfigs["demo"].Config.Contexts["admin"].Namespace)
 	require.Equal(t, "team-b", runtime.Kubeconfigs["demo"].Contexts["ops"].Namespace)
 	require.Equal(t, "team-b", runtime.Kubeconfigs["demo"].Config.Contexts["ops"].Namespace)
+}
+
+func TestCompileResolvesKubeconfigPathAgainstBaseDir(t *testing.T) {
+	cfg := Config{
+		BaseDir: "/tmp/kube",
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path: "@/target-kubeconfig.yaml",
+			},
+		},
+	}
+
+	runtime, err := NewCompiler().Compile(&cfg)
+	require.NoError(t, err)
+	require.Equal(t, "/tmp/kube/target-kubeconfig.yaml", runtime.Kubeconfigs["demo"].Path)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	DefaultWorkspace string                 `mapstructure:"default_workspace,omitempty" json:"default_workspace,omitempty" yaml:"default_workspace,omitempty"`
 	Workspaces       map[string]*Workspace  `mapstructure:"workspaces,omitempty" json:"workspaces,omitempty" yaml:"workspaces,omitempty"`
 	Kubeconfigs      map[string]*Kubeconfig `mapstructure:"kubeconfigs,omitempty" json:"kubeconfigs,omitempty" yaml:"kubeconfigs,omitempty"`
+	BaseDir          string                 `mapstructure:"base_dir,omitempty" json:"base_dir,omitempty" yaml:"base_dir,omitempty"`
 }
 
 type Workspace struct {

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -7,6 +7,7 @@ import (
 
 type RuntimeConfig struct {
 	Version string
+	BaseDir string
 
 	Workspaces       map[string]*RuntimeWorkspace
 	Kubeconfigs      map[string]*RuntimeKubeconfig

--- a/pkg/service/login.go
+++ b/pkg/service/login.go
@@ -50,9 +50,9 @@ func (s *LoginService) loginWithCommand(ctx context.Context, _ *config.RuntimeAu
 		if err := tmpFile.Close(); err != nil {
 			panic(err)
 		}
-		if err := os.Remove(tmpFile.Name()); err != nil {
-			panic(err)
-		}
+		// if err := os.Remove(tmpFile.Name()); err != nil {
+		// 	panic(err)
+		// }
 	}()
 
 	// Add var so that login uses temporary kubeconfig file during login


### PR DESCRIPTION
Eliminate the global baseDir variable and related flags. Path resolution for kubeconfigs now uses the BaseDir field from the config struct, defaulting to $HOME/.kube if unset. This improves testability and makes path resolution explicit and per-config. Updates all affected commands and tests.