### PR TITLE
feat(config): support env_file for login and exec env merging

### DIFF
--- a/cmd/kubecfg/use.go
+++ b/cmd/kubecfg/use.go
@@ -134,7 +134,8 @@ func runUseCmd(workspaceName, kubeconfigName string, skipLogin bool, identityFil
 		return err
 	}
 
-	fmt.Printf("Using kubeconfig: %s/%s\n", workspaceName, kubeconfigName)
+	cmdutil.Printf(`{{ "✔" | FgGreen }} Using kubeconfig {{ .Workspace | FgYellow }}/{{ .Kubeconfig | FgCyan }}`, cmdutil.Data{"Workspace": workspaceName, "Kubeconfig": kubeconfigName})
+
 	return nil
 }
 
@@ -175,7 +176,8 @@ func runUseCmdFzf(workspaceName string, skipLogin bool, identityFile string, wai
 	if err := setConfig(runtime.BaseDir, rk.Path); err != nil {
 		return err
 	}
-	fmt.Printf("Using kubeconfig: %s/%s\n", workspace, selected)
+	cmdutil.Printf(`{{ "✔" | FgGreen }} Using kubeconfig {{ .Workspace | FgYellow }}/{{ .Kubeconfig | FgCyan }}`, cmdutil.Data{"Workspace": workspace, "Kubeconfig": selected})
+
 	return nil
 }
 

--- a/pkg/cmdutil/renderer.go
+++ b/pkg/cmdutil/renderer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -651,6 +652,21 @@ func RenderLine(w io.Writer, width int) error {
 		}
 	}
 	return nil
+}
+
+// Println prints msg on new line to stdout
+func Println(msg string) {
+	RenderOnce(os.Stdout, Data{"Msg": msg}, NewContainer(nil, NewElement("{{.Msg}}")))
+}
+
+// Printf prints formated text with data as input
+func Printf(msgfmt string, data Data) {
+	RenderOnce(os.Stdout, data, NewContainer(nil, NewElement(msgfmt)))
+}
+
+// Fprintf is same as Printf but prints to provided writer
+func Fprintf(w io.Writer, msgfmt string, data Data) {
+	RenderOnce(w, data, NewContainer(nil, NewElement(msgfmt)))
 }
 
 // RenderOnce renders containers a single time to the provided writer.

--- a/pkg/cmdutil/renderer.go
+++ b/pkg/cmdutil/renderer.go
@@ -656,17 +656,17 @@ func RenderLine(w io.Writer, width int) error {
 
 // Println prints msg on new line to stdout
 func Println(msg string) {
-	RenderOnce(os.Stdout, Data{"Msg": msg}, NewContainer(nil, NewElement("{{.Msg}}")))
+	_ = RenderOnce(os.Stdout, Data{"Msg": msg}, NewContainer(nil, NewElement("{{.Msg}}")))
 }
 
 // Printf prints formated text with data as input
 func Printf(msgfmt string, data Data) {
-	RenderOnce(os.Stdout, data, NewContainer(nil, NewElement(msgfmt)))
+	_ = RenderOnce(os.Stdout, data, NewContainer(nil, NewElement(msgfmt)))
 }
 
 // Fprintf is same as Printf but prints to provided writer
 func Fprintf(w io.Writer, msgfmt string, data Data) {
-	RenderOnce(w, data, NewContainer(nil, NewElement(msgfmt)))
+	_ = RenderOnce(w, data, NewContainer(nil, NewElement(msgfmt)))
 }
 
 // RenderOnce renders containers a single time to the provided writer.

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -191,29 +192,123 @@ func envSliceToMap(env []string) map[string]string {
 	return m
 }
 
-func resolveCredentialSource(l *LoginAuth) RuntimeCredentialSource {
+func mergeLoginEnv(env []string, fileEnv map[string]string) map[string]string {
+	merged := envSliceToMap(env)
+	for key, value := range fileEnv {
+		merged[key] = value
+	}
+	return merged
+}
+
+func mergeExecEnv(env []ExecEnvVar, fileEnv map[string]string) []ExecEnvVar {
+	merged := make([]ExecEnvVar, 0, len(env)+len(fileEnv))
+	seen := make(map[string]struct{}, len(env)+len(fileEnv))
+
+	for _, entry := range env {
+		if _, ok := fileEnv[entry.Name]; ok {
+			continue
+		}
+		merged = append(merged, entry)
+		seen[entry.Name] = struct{}{}
+	}
+
+	for key, value := range fileEnv {
+		merged = append(merged, ExecEnvVar{Name: key, Value: value})
+		seen[key] = struct{}{}
+	}
+
+	for _, entry := range env {
+		if _, ok := seen[entry.Name]; ok {
+			continue
+		}
+		merged = append(merged, entry)
+	}
+
+	return merged
+}
+
+func resolveCredentialSource(l *LoginAuth) (RuntimeCredentialSource, error) {
 	if l == nil {
-		return nil
+		return nil, nil
+	}
+
+	envMap, err := loadEnvFile(l.EnvFile)
+	if err != nil {
+		return nil, err
 	}
 
 	return &RuntimeLoginCredentialSource{
 		Command: l.Command,
 		Args:    l.Args,
-		Env:     envSliceToMap(l.Env),
+		Env:     mergeLoginEnv(l.Env, envMap),
 		Import: RuntimeLoginImport{
 			Context: l.CopyFromContextName,
 		},
-	}
+	}, nil
 }
 
-func resolveAuthInfosExec(e *ExecConfig) *api.ExecConfig {
-	if e == nil {
-		return nil
+func loadEnvFile(path string) (map[string]string, error) {
+	res := make(map[string]string)
+	if strings.TrimSpace(path) == "" {
+		return res, nil
 	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return res, fmt.Errorf("open env file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return res, fmt.Errorf("invalid env line %d: missing '='", lineNumber)
+		}
+
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		if key == "" {
+			return res, fmt.Errorf("invalid env line %d: empty key", lineNumber)
+		}
+
+		// Remove surrounding quotes commonly used in .env files.
+		value = strings.Trim(value, `"'`)
+		res[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return res, fmt.Errorf("read env file: %w", err)
+	}
+
+	return res, nil
+}
+
+func resolveAuthInfosExec(e *ExecConfig) (*api.ExecConfig, error) {
+	if e == nil {
+		return nil, nil
+	}
+
+	envMap, err := loadEnvFile(e.EnvFile)
+	if err != nil {
+		return nil, err
+	}
+
 	return &api.ExecConfig{
 		Command:                 e.Command,
 		Args:                    e.Args,
-		Env:                     resolveExecEnvVars(e.Env),
+		Env:                     resolveExecEnvVars(mergeExecEnv(e.Env, envMap)),
 		APIVersion:              e.APIVersion,
 		InstallHint:             e.InstallHint,
 		ProvideClusterInfo:      e.ProvideClusterInfo,
@@ -221,7 +316,7 @@ func resolveAuthInfosExec(e *ExecConfig) *api.ExecConfig {
 		InteractiveMode:         api.ExecInteractiveMode(e.InteractiveMode),
 		StdinUnavailable:        e.StdinUnavailable,
 		StdinUnavailableMessage: e.StdinUnavailableMessage,
-	}
+	}, nil
 }
 
 func compileContexts(rkc *RuntimeKubeconfig, kc *Kubeconfig) error {
@@ -506,6 +601,16 @@ func (c *AuthInfoCompiler) Compile(name string, in *AuthInfo) (*RuntimeAuthInfo,
 		return nil, fmt.Errorf("authinfo %q contains encrypted fields; provide --identity-file or a passphrase", name)
 	}
 
+	execConfig, err := resolveAuthInfosExec(in.Exec)
+	if err != nil {
+		return nil, fmt.Errorf("authinfo %q exec env_file: %w", name, err)
+	}
+
+	credentialSource, err := resolveCredentialSource(in.Login)
+	if err != nil {
+		return nil, fmt.Errorf("authinfo %q login env_file: %w", name, err)
+	}
+
 	rai := &RuntimeAuthInfo{
 		Name: name,
 		AuthInfo: &api.AuthInfo{
@@ -525,10 +630,10 @@ func (c *AuthInfoCompiler) Compile(name string, in *AuthInfo) (*RuntimeAuthInfo,
 			Username:             in.Username,
 			Password:             in.Password,
 			AuthProvider:         (*api.AuthProviderConfig)(in.AuthProvider),
-			Exec:                 resolveAuthInfosExec(in.Exec),
+			Exec:                 execConfig,
 			Extensions:           in.Extensions,
 		},
-		CredentialSource: resolveCredentialSource(in.Login),
+		CredentialSource: credentialSource,
 	}
 
 	if in.EncryptedToken != "" {

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -257,7 +257,11 @@ func loadEnvFile(path string) (map[string]string, error) {
 	if err != nil {
 		return res, fmt.Errorf("open env file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
 	scanner := bufio.NewScanner(file)
 

--- a/pkg/config/compile_test.go
+++ b/pkg/config/compile_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"filippo.io/age"
@@ -231,4 +233,131 @@ func TestCompileResolvesKubeconfigPathAgainstBaseDir(t *testing.T) {
 	runtime, err := NewCompiler().Compile(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, "/tmp/kube/target-kubeconfig.yaml", runtime.Kubeconfigs["demo"].Path)
+}
+
+func TestCompileMergesLoginEnvFileWithoutMutatingProcessEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	envFile := filepath.Join(tempDir, "login.env")
+	err := os.WriteFile(envFile, []byte("FROM_FILE=file-value\nQUOTED=\"quoted value\"\n"), 0o600)
+	require.NoError(t, err)
+
+	_, existedBefore := os.LookupEnv("FROM_FILE")
+	require.False(t, existedBefore)
+
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path: "/tmp/demo",
+				AuthInfos: map[string]*AuthInfo{
+					"user": {
+						Login: &LoginAuth{
+							Command:             "login",
+							Env:                 []string{"FROM_FILE=inline-value", "KEEP=keep-value"},
+							EnvFile:             envFile,
+							CopyFromContextName: "ctx",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runtime, err := NewCompiler().Compile(&cfg)
+	require.NoError(t, err)
+
+	source, ok := runtime.Kubeconfigs["demo"].AuthInfos["user"].CredentialSource.(*RuntimeLoginCredentialSource)
+	require.True(t, ok)
+	require.Equal(t, "file-value", source.Env["FROM_FILE"])
+	require.Equal(t, "keep-value", source.Env["KEEP"])
+	require.Equal(t, "quoted value", source.Env["QUOTED"])
+	_, existsAfter := os.LookupEnv("FROM_FILE")
+	require.False(t, existsAfter)
+}
+
+func TestCompileMergesExecEnvFileWithEnvFileWinning(t *testing.T) {
+	tempDir := t.TempDir()
+	envFile := filepath.Join(tempDir, "exec.env")
+	err := os.WriteFile(envFile, []byte("FROM_FILE=file-value\nQUOTED='quoted value'\n"), 0o600)
+	require.NoError(t, err)
+
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path: "/tmp/demo",
+				AuthInfos: map[string]*AuthInfo{
+					"user": {
+						Exec: &ExecConfig{
+							Command: "exec",
+							Env: []ExecEnvVar{
+								{Name: "FROM_FILE", Value: "inline-value"},
+								{Name: "KEEP", Value: "keep-value"},
+							},
+							EnvFile: envFile,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runtime, err := NewCompiler().Compile(&cfg)
+	require.NoError(t, err)
+
+	execCfg := runtime.Kubeconfigs["demo"].AuthInfos["user"].AuthInfo.Exec
+	require.NotNil(t, execCfg)
+	require.ElementsMatch(t, []map[string]string{
+		{"name": "FROM_FILE", "value": "file-value"},
+		{"name": "KEEP", "value": "keep-value"},
+		{"name": "QUOTED", "value": "quoted value"},
+	}, []map[string]string{
+		{"name": execCfg.Env[0].Name, "value": execCfg.Env[0].Value},
+		{"name": execCfg.Env[1].Name, "value": execCfg.Env[1].Value},
+		{"name": execCfg.Env[2].Name, "value": execCfg.Env[2].Value},
+	})
+}
+
+func TestCompileFailsWhenLoginEnvFileIsInvalid(t *testing.T) {
+	tempDir := t.TempDir()
+	envFile := filepath.Join(tempDir, "login.env")
+	err := os.WriteFile(envFile, []byte("BROKEN_LINE\n"), 0o600)
+	require.NoError(t, err)
+
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path: "/tmp/demo",
+				AuthInfos: map[string]*AuthInfo{
+					"user": {
+						Login: &LoginAuth{EnvFile: envFile},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = NewCompiler().Compile(&cfg)
+	require.EqualError(t, err, "authinfo \"user\" login env_file: invalid env line 1: missing '='")
+}
+
+func TestCompileFailsWhenExecEnvFileIsInvalid(t *testing.T) {
+	tempDir := t.TempDir()
+	envFile := filepath.Join(tempDir, "exec.env")
+	err := os.WriteFile(envFile, []byte("BROKEN_LINE\n"), 0o600)
+	require.NoError(t, err)
+
+	cfg := Config{
+		Kubeconfigs: map[string]*Kubeconfig{
+			"demo": {
+				Path: "/tmp/demo",
+				AuthInfos: map[string]*AuthInfo{
+					"user": {
+						Exec: &ExecConfig{EnvFile: envFile},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = NewCompiler().Compile(&cfg)
+	require.EqualError(t, err, "authinfo \"user\" exec env_file: invalid env line 1: missing '='")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,6 +81,7 @@ type LoginAuth struct {
 	Args                []string `json:"args"`
 	OutputMode          string   `json:"output_mode"`
 	Env                 []string `json:"env"`
+	EnvFile             string   `mapstructure:"env_file" json:"env_file" yaml:"env_file"`
 	CopyFromContextName string   `mapstructure:"copy_from_context_name" json:"copy_from_context_name" yaml:"copy_from_context_name"`
 }
 
@@ -100,6 +101,7 @@ type ExecConfig struct {
 	Command                 string       `json:"command"`
 	Args                    []string     `json:"args"`
 	Env                     []ExecEnvVar `json:"env"`
+	EnvFile                 string       `mapstructure:"env_file" json:"env_file" yaml:"env_file"`
 	APIVersion              string       `json:"apiVersion,omitempty"`
 	InstallHint             string       `json:"installHint,omitempty"`
 	ProvideClusterInfo      bool         `json:"provideClusterInfo"`


### PR DESCRIPTION
Add support for specifying an env_file in both login and exec auth configs. Environment variables from the file are merged with inline env, with file values taking precedence. Includes tests for correct merging and error handling.