### PR TITLE
feat(use): add interactive kubeconfig selection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Login pre-hooks](#login-pre-hooks)
   - [Encrypted Fields](#encrypted-fields)
   - [Describing Workspaces](#describing-workspaces)
+  - [Selecting kubeconfigs](#selecting-kubeconfigs)
 - [API Reference](#api-reference)
 - [CLI Reference](#cli-reference)
 - [License](#license)
@@ -186,6 +187,20 @@ If a workspace contains kubeconfigs with encrypted fields, provide an identity f
 
 ```bash
 kubecfg describe workspace homelab --identity-file ~/.config/kubecfg/age.txt
+```
+
+## Selecting Kubeconfigs
+
+Use `kubecfg use` to set a kubeconfig as the active one. The `use` command updates the symlink to `~/.kube/config` pointing it to a rendered kubeconfig. See [Rendering Kubeconfigs](#rendering-kubeconfigs) for more information.
+
+`kubecfg use` searches for kubeconfig files and displays them in a fuzzy finder allowing you to interactively select a kubeconfig to activate.
+
+`kubecfg use` searches for kubeconfigs using this pattern by default `~/.kube/*.yaml`. This can be overridden with `--glob`. 
+
+For example:
+
+```bash
+kubecfg use --glob ~/Projects/kube/*.yaml --glob ~/.kube/conf.d/*.yml
 ```
 
 # API Reference

--- a/cmd/kubecfg/main.go
+++ b/cmd/kubecfg/main.go
@@ -128,6 +128,7 @@ func main() {
 	rootCmd.AddCommand(newLoginCmd())
 	rootCmd.AddCommand(newEncryptCmd())
 	rootCmd.AddCommand(newDescribeCmd())
+	rootCmd.AddCommand(newUseCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/kubecfg/render.go
+++ b/cmd/kubecfg/render.go
@@ -255,40 +255,9 @@ func pickContext(rc *config.RuntimeConfig, workspaceName string) (string, string
 		close(inputChan)
 	}()
 
-	outputChan := make(chan string, 1)
-
-	// Build fzf.Options
-	options, err := fzf.ParseOptions(
-		true,
-		[]string{"--reverse", "--border", "--height=40%"},
-	)
+	selected, err := pick(inputChan)
 	if err != nil {
-		return "", "", fmt.Errorf("fzf exit error %d: %w", fzf.ExitError, err)
-	}
-
-	// Set up input and output channels
-	options.Input = inputChan
-	options.Output = outputChan
-
-	// Run fzf
-	code, err := fzfRun(options)
-	if err != nil {
-		return "", "", fmt.Errorf("fzf exited with code %d: %w", code, err)
-	}
-
-	switch code {
-	case fzf.ExitInterrupt, fzf.ExitNoMatch:
-		return "", "", errNoSelection
-	case fzf.ExitOk:
-	default:
-		return "", "", fmt.Errorf("fzf exited with code %d", code)
-	}
-
-	var selected string
-	select {
-	case selected = <-outputChan:
-	default:
-		return "", "", fmt.Errorf("fzf exited with code %d without a selection", code)
+		return "", "", err
 	}
 
 	ss := strings.Split(selected, "/")
@@ -297,4 +266,44 @@ func pickContext(rc *config.RuntimeConfig, workspaceName string) (string, string
 	}
 
 	return workspaceName, selected, nil
+}
+
+func pick(input chan string) (string, error) {
+	outputChan := make(chan string, 1)
+
+	// Build fzf.Options
+	options, err := fzf.ParseOptions(
+		true,
+		[]string{"--reverse", "--border", "--height=40%", "--query=\"'vgr.yaml\""},
+	)
+	if err != nil {
+		return "", fmt.Errorf("fzf exit error %d: %w", fzf.ExitError, err)
+	}
+
+	// Set up input and output channels
+	options.Input = input
+	options.Output = outputChan
+
+	// Run fzf
+	code, err := fzfRun(options)
+	if err != nil {
+		return "", fmt.Errorf("fzf exited with code %d: %w", code, err)
+	}
+
+	switch code {
+	case fzf.ExitInterrupt, fzf.ExitNoMatch:
+		return "", errNoSelection
+	case fzf.ExitOk:
+	default:
+		return "", fmt.Errorf("fzf exited with code %d", code)
+	}
+
+	var selected string
+	select {
+	case selected = <-outputChan:
+	default:
+		return "", fmt.Errorf("fzf exited with code %d without a selection", code)
+	}
+
+	return selected, nil
 }

--- a/cmd/kubecfg/use.go
+++ b/cmd/kubecfg/use.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/amimof/kubecfg/pkg/cmdutil"
+	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func newUseCmd() *cobra.Command {
+	var glob []string
+	cmd := &cobra.Command{
+		Use:          "use",
+		Short:        "Use a rendered kubeconfig",
+		Long:         `Select and activate an existing kubeconfig file`,
+		Example:      `  kubecfg use`,
+		Args:         cobra.ExactArgs(0),
+		SilenceUsage: true,
+		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
+			return runUseCmd(glob)
+		}),
+	}
+	h, _ := os.UserHomeDir()
+
+	cmd.Flags().StringArrayVar(&glob, "glob", []string{path.Join(h, ".kube/*.yaml")}, "List files matching a pattern to include. This flag can be used multiple times.")
+
+	return cmd
+}
+
+func runUseCmd(glob []string) error {
+	selected, err := pickKubeconfig(glob)
+	if err != nil {
+		return err
+	}
+
+	compiler := config.NewCompiler()
+	runtime, err := compiler.Compile(&cfg)
+	if err != nil {
+		return err
+	}
+
+	err = setConfig(runtime.BaseDir, selected)
+	if err != nil {
+		return err
+	}
+
+	cmdutil.Printf(`{{ "✔" | FgGreen }} Using kubeconfig {{ .Kubeconfig | FgCyan }}`, cmdutil.Data{"Kubeconfig": selected})
+	return nil
+}
+
+func pickKubeconfig(globs []string) (string, error) {
+	// Assemble items in Cfg
+	kubeconfigs := ListKubeconfigs(globs)
+
+	inputChan := make(chan string)
+	go func() {
+		for _, name := range kubeconfigs {
+			inputChan <- name
+		}
+		close(inputChan)
+	}()
+
+	selected, err := pick(inputChan)
+	if err != nil {
+		return "", err
+	}
+
+	return selected, nil
+}
+
+func ListKubeconfigs(globs []string) []string {
+	kubeConfigs := []string{}
+	for _, iglobs := range globs {
+		matches, err := filepath.Glob(iglobs)
+		if err != nil {
+			continue
+		}
+		kubeConfigs = append(kubeConfigs, matches...)
+	}
+
+	var res []string
+
+	for _, kubeConfig := range kubeConfigs {
+		if info, err := os.Stat(kubeConfig); err == nil {
+			if !info.IsDir() {
+
+				_, err := clientcmd.LoadFromFile(kubeConfig)
+				if err != nil {
+					return nil
+				}
+
+				res = append(res, info.Name())
+			}
+		}
+	}
+	return res
+}


### PR DESCRIPTION
Introduce `kubecfg use` command to interactively select and activate a kubeconfig file using fuzzy finder. Supports multiple --glob patterns for custom search locations. Updates symlink to ~/.kube/config for easier context switching. Improves usability for users managing multiple kubeconfigs.