### PR TITLE
feat(which): add which command to show active kubeconfig

### DIFF
--- a/cmd/kubecfg/main.go
+++ b/cmd/kubecfg/main.go
@@ -129,6 +129,7 @@ func main() {
 	rootCmd.AddCommand(newEncryptCmd())
 	rootCmd.AddCommand(newDescribeCmd())
 	rootCmd.AddCommand(newUseCmd())
+	rootCmd.AddCommand(newWhichCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/kubecfg/render.go
+++ b/cmd/kubecfg/render.go
@@ -274,7 +274,7 @@ func pick(input chan string) (string, error) {
 	// Build fzf.Options
 	options, err := fzf.ParseOptions(
 		true,
-		[]string{"--reverse", "--border", "--height=40%", "--query=\"'vgr.yaml\""},
+		[]string{"--reverse", "--border", "--height=40%"},
 	)
 	if err != nil {
 		return "", fmt.Errorf("fzf exit error %d: %w", fzf.ExitError, err)

--- a/cmd/kubecfg/which.go
+++ b/cmd/kubecfg/which.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/amimof/kubecfg/pkg/cmdutil"
+	"github.com/amimof/kubecfg/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func newWhichCmd() *cobra.Command {
+	var plain bool
+	cmd := &cobra.Command{
+		Use:          "which",
+		Short:        "which kubeconfig is currently active",
+		Long:         `Displays which kubeconfig is symlinked to ~/.kube/config`,
+		Example:      `  kubecfg which`,
+		Args:         cobra.ExactArgs(0),
+		SilenceUsage: true,
+		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
+			return runWhichCmd(plain)
+		}),
+	}
+	cmd.Flags().BoolVar(&plain, "plain", false, "Only print file path to active kubeconfig")
+	return cmd
+}
+
+func runWhichCmd(plain bool) error {
+	compiler := config.NewCompiler()
+	runtime, err := compiler.Compile(&cfg)
+	if err != nil {
+		return err
+	}
+
+	dst := path.Join(runtime.BaseDir, "config")
+	_, err = os.Stat(dst)
+	if err != nil {
+		return err
+	}
+
+	sEval, err := filepath.EvalSymlinks(dst)
+	if err != nil {
+		return err
+	}
+
+	sBase := filepath.Base(sEval)
+
+	if !plain {
+		cmdutil.Printf(`{{ .Dst | FgGreen }} ➜ {{ .Name | FgCyan }} {{ printf "(%s)" .Symlink | FgHiBlack }}`, cmdutil.Data{"Dst": dst, "Name": sBase, "Symlink": sEval})
+		return nil
+	}
+
+	fmt.Println(sEval)
+
+	return nil
+}


### PR DESCRIPTION
Adds a new 'which' command that displays the currently active kubeconfig file by resolving the symlink at ~/.kube/config. Supports a --plain flag to print only the file path. This helps users quickly identify which kubeconfig is in use.