### PR TITLE
feat(config): support multiple age identity files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This lets you manage `kubecfg.yaml` like a dotfile. Version it, sync it across m
 
 `kubecfg render mainframe --workspace homelab` same as previous command
 
-`kubecfg render mainframe --identity-file ~/.config/kubecfg/age.txt` decrypts `encryptedToken` and other encrypted auth fields during compile.
+`kubecfg render mainframe` decrypts `encryptedToken` and other encrypted auth fields during compile when `identity_files` is configured.
 
 ## Login Sources And Imports
 
@@ -142,6 +142,14 @@ If `import_ref.cluster` or `import_ref.auth_info` is omitted, kubecfg defaults t
 
 Use `kubecfg encrypt` to generate an armored age string and paste it into a encrypted auth field.
 
+Generate an age key pair first. This command writes an identity file containing the private key. It also prints the corresponding public key to stdout:
+
+```bash
+age-keygen -o ~/age.txt
+```
+
+Use the public key when encrypting values:
+
 ```bash
 kubecfg encrypt --public-key age1...
 ```
@@ -165,8 +173,15 @@ kubeconfigs:
 Render that kubeconfig with either an age identity file or a passphrase-backed age secret:
 
 ```bash
-kubecfg render mainframe --identity-file ~/.config/kubecfg/age.txt
-kubecfg login mainframe admin --identity-file ~/.config/kubecfg/age.txt
+kubecfg render mainframe
+kubecfg login mainframe admin
+```
+
+Add age identity files to your config to enable non-interactive decryption:
+
+```yaml
+identity_files:
+  - ~/.config/kubecfg/age.txt
 ```
 
 If both `token` and `encryptedToken` are set, `encryptedToken` wins.
@@ -185,10 +200,10 @@ To inspect a single workspace, pass the workspace name:
 kubecfg describe workspace homelab
 ```
 
-If a workspace contains kubeconfigs with encrypted fields, provide an identity file when describing it:
+If a workspace contains kubeconfigs with encrypted fields, configure `identity_files` first if you do not want to enter a passphrase interactively:
 
 ```bash
-kubecfg describe workspace homelab --identity-file ~/.config/kubecfg/age.txt
+kubecfg describe workspace homelab
 ```
 
 ## Selecting Kubeconfigs
@@ -291,9 +306,8 @@ kubeconfigs:
         # Pick one primary auth mechanism for this auth info.
         token: "<redacted>"
 
-        # Encrypted variants are decrypted during Compile() when you run
-        # `kubecfg render` or `kubecfg login` with `--identity-file` or a
-        # passphrase on stdin.
+        # Encrypted variants are decrypted during Compile() when
+        # `identity_files` is configured or a passphrase is provided on stdin.
         # encryptedToken: |
         #   -----BEGIN AGE ENCRYPTED FILE-----
         #   ...

--- a/cmd/kubecfg/decrypt_flags.go
+++ b/cmd/kubecfg/decrypt_flags.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amimof/kubecfg/pkg/decrypt"
 )
 
-func newCompilerWithOptionalDecryptor(cfg *config.Config, identityFile string) (*config.Compiler, error) {
+func newCompilerWithOptionalDecryptor(cfg *config.Config, identityFile []string) (*config.Compiler, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
@@ -27,23 +27,28 @@ func newCompilerWithOptionalDecryptor(cfg *config.Config, identityFile string) (
 	return config.NewCompiler(compilerOpts...), nil
 }
 
-func loadAgeDecryptor(identityFile string) (*decrypt.AgeDecryptor, error) {
-	if identityFile != "" {
-		f, err := os.Open(identityFile)
-		if err != nil {
-			return nil, err
-		}
-		defer func() {
-			if err := f.Close(); err != nil {
-				panic(err)
+func loadAgeDecryptor(identityFiles []string) (*decrypt.AgeDecryptor, error) {
+	if len(identityFiles) > 0 {
+
+		var identities []age.Identity
+		for _, identityFile := range identityFiles {
+
+			f, err := os.Open(config.ResolvePath("", identityFile))
+			if err != nil {
+				return nil, err
 			}
-		}()
+			defer func() {
+				if err := f.Close(); err != nil {
+					panic(err)
+				}
+			}()
 
-		identities, err := age.ParseIdentities(f)
-		if err != nil {
-			return nil, err
+			parsedIdentities, err := age.ParseIdentities(f)
+			if err != nil {
+				return nil, err
+			}
+			identities = append(identities, parsedIdentities...)
 		}
-
 		return decrypt.NewAgeDecryptor(identities...)
 	}
 

--- a/cmd/kubecfg/describe_workspace.go
+++ b/cmd/kubecfg/describe_workspace.go
@@ -13,28 +13,24 @@ import (
 var describeWorkspaceStdout io.Writer = os.Stdout
 
 func newDescribeWorkspaceCmd() *cobra.Command {
-	var identityFile string
-
 	cmd := &cobra.Command{
 		Use:   "workspace [WORKSPACE]",
 		Short: "Show workspace details",
 		Long:  `Show a workspace and its kubeconfigs in a readable format.`,
 		Example: `  kubecfg describe workspace homelab
-  kubecfg describe workspace homelab --identity-file ~/.config/kubecfg/age.txt`,
+	  kubecfg describe workspace homelab`,
 		Args:         cobra.MinimumNArgs(0),
 		SilenceUsage: true,
 		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
-			return runDescribeWorkspaceCmd(args, identityFile, describeWorkspaceStdout)
+			return runDescribeWorkspaceCmd(args, describeWorkspaceStdout)
 		}),
 	}
-
-	cmd.PersistentFlags().StringVar(&identityFile, "identity-file", "", "Age identity used to decrypt fields in configuration")
 
 	return cmd
 }
 
-func runDescribeWorkspaceCmd(args []string, identityFile string, stdout io.Writer) error {
-	compiler, err := newCompilerWithOptionalDecryptor(&cfg, identityFile)
+func runDescribeWorkspaceCmd(args []string, stdout io.Writer) error {
+	compiler, err := newCompilerWithOptionalDecryptor(&cfg, cfg.IdentityFiles)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubecfg/describe_workspace_test.go
+++ b/cmd/kubecfg/describe_workspace_test.go
@@ -18,7 +18,7 @@ func TestRunDescribeWorkspaceCmdRendersDefaultKubeconfig(t *testing.T) {
 	cfg = newDescribeWorkspaceTestConfig()
 
 	var stdout bytes.Buffer
-	err := runDescribeWorkspaceCmd([]string{"work"}, "", &stdout)
+	err := runDescribeWorkspaceCmd([]string{"work"}, &stdout)
 	require.NoError(t, err)
 
 	output := stdout.String()
@@ -70,7 +70,7 @@ func TestRunDescribeWorkspaceCmdRendersEmptyDefaultKubeconfigWhenUnset(t *testin
 	cfg.Workspaces["work"].DefaultKubeconfig = ""
 
 	var stdout bytes.Buffer
-	err := runDescribeWorkspaceCmd([]string{"work"}, "", &stdout)
+	err := runDescribeWorkspaceCmd([]string{"work"}, &stdout)
 	require.NoError(t, err)
 
 	for _, line := range strings.Split(stdout.String(), "\n") {

--- a/cmd/kubecfg/login.go
+++ b/cmd/kubecfg/login.go
@@ -20,7 +20,6 @@ var (
 func newLoginCmd() *cobra.Command {
 	var (
 		workspaceName string
-		identityFile  string
 	)
 	cmd := &cobra.Command{
 		Use:   "login [KUBECONFIG] [CONTEXT]",
@@ -31,18 +30,17 @@ func newLoginCmd() *cobra.Command {
 		Args:         cobra.ExactArgs(2),
 		SilenceUsage: true,
 		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
-			return runLoginCmd(workspaceName, args[0], args[1], identityFile)
+			return runLoginCmd(workspaceName, args[0], args[1])
 		}),
 	}
 
 	cmd.PersistentFlags().StringVarP(&workspaceName, "workspace", "w", "", "Workspace")
-	cmd.PersistentFlags().StringVar(&identityFile, "identity-file", "", "Age identity used to decrypt fields in configuration")
 
 	return cmd
 }
 
-func runLoginCmd(workspaceName, kubeconfigName, contextName, identityFile string) error {
-	compiler, err := newCompilerWithOptionalDecryptor(&cfg, identityFile)
+func runLoginCmd(workspaceName, kubeconfigName, contextName string) error {
+	compiler, err := newCompilerWithOptionalDecryptor(&cfg, cfg.IdentityFiles)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubecfg/login_test.go
+++ b/cmd/kubecfg/login_test.go
@@ -31,7 +31,7 @@ func TestRunLoginCmdImportsReferencedContext(t *testing.T) {
 	loginStdout = &stdout
 	loginStderr = &stderr
 
-	err := runLoginCmd("work", "vgr", "ctx1", "")
+	err := runLoginCmd("work", "vgr", "ctx1")
 	require.NoError(t, err)
 	require.Greater(t, stdout.Len(), 64*1024)
 	require.Greater(t, stderr.Len(), 64*1024)
@@ -71,7 +71,7 @@ func TestRunLoginCmdDoesNotMutateLoginSourceEnv(t *testing.T) {
 	require.NotNil(t, source)
 	require.NotContains(t, source.Env, "KUBECONFIG")
 
-	err = runLoginCmd("work", "vgr", "ctx1", "")
+	err = runLoginCmd("work", "vgr", "ctx1")
 	require.NoError(t, err)
 	require.NotContains(t, source.Env, "KUBECONFIG")
 }
@@ -93,7 +93,7 @@ func TestRunLoginCmdReturnsHelpfulErrorWhenCommandCannotStart(t *testing.T) {
 	loginStdout = &bytes.Buffer{}
 	loginStderr = &bytes.Buffer{}
 
-	err := runLoginCmd("work", "vgr", "ctx1", "")
+	err := runLoginCmd("work", "vgr", "ctx1")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "login source \"shared\": run command")
 	require.Contains(t, err.Error(), "missing-login-binary")
@@ -116,7 +116,7 @@ func TestRunLoginCmdReturnsHelpfulErrorWhenGeneratedKubeconfigIsInvalid(t *testi
 	loginStdout = &bytes.Buffer{}
 	loginStderr = &bytes.Buffer{}
 
-	err := runLoginCmd("work", "vgr", "ctx1", "")
+	err := runLoginCmd("work", "vgr", "ctx1")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "login source \"shared\": load generated kubeconfig")
 	require.Contains(t, err.Error(), "cannot unmarshal string")

--- a/cmd/kubecfg/render.go
+++ b/cmd/kubecfg/render.go
@@ -29,7 +29,6 @@ func newRenderCmd() *cobra.Command {
 	var (
 		workspaceName string
 		skipLogin     bool
-		identityFile  string
 		waitTimeout   time.Duration
 	)
 
@@ -43,14 +42,13 @@ func newRenderCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE: withConfig(func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return runRenderCmdFzf(cmd.Context(), workspaceName, skipLogin, identityFile, waitTimeout)
+				return runRenderCmdFzf(cmd.Context(), workspaceName, skipLogin, waitTimeout)
 			}
-			return runRenderCmd(cmd.Context(), workspaceName, args[0], skipLogin, identityFile, waitTimeout)
+			return runRenderCmd(cmd.Context(), workspaceName, args[0], skipLogin, waitTimeout)
 		}),
 	}
 
 	cmd.PersistentFlags().StringVarP(&workspaceName, "workspace", "w", "", "Workspace")
-	cmd.PersistentFlags().StringVar(&identityFile, "identity-file", "", "Age identity used to decrypt fields in configuration")
 	cmd.PersistentFlags().BoolVar(&skipLogin, "skip-login", false, "Skip execution of login flow prior to kubeconfig rendering")
 	cmd.PersistentFlags().DurationVar(&waitTimeout, "timeout", time.Second*30, "How long in seconds to wait for login opearation to finish before giving up")
 
@@ -82,8 +80,8 @@ func setConfig(baseDir, name string) error {
 	return os.Symlink(name, path.Join(baseDir, "config"))
 }
 
-func runRenderCmd(ctx context.Context, workspaceName, kubeconfigName string, skipLogin bool, identityFile string, waitTimeout time.Duration) error {
-	compiler, err := newCompilerWithOptionalDecryptor(&cfg, identityFile)
+func runRenderCmd(ctx context.Context, workspaceName, kubeconfigName string, skipLogin bool, waitTimeout time.Duration) error {
+	compiler, err := newCompilerWithOptionalDecryptor(&cfg, cfg.IdentityFiles)
 	if err != nil {
 		return err
 	}
@@ -143,8 +141,8 @@ func runRenderCmd(ctx context.Context, workspaceName, kubeconfigName string, ski
 	return nil
 }
 
-func runRenderCmdFzf(ctx context.Context, workspaceName string, skipLogin bool, identityFile string, waitTimeout time.Duration) error {
-	compiler, err := newCompilerWithOptionalDecryptor(&cfg, identityFile)
+func runRenderCmdFzf(ctx context.Context, workspaceName string, skipLogin bool, waitTimeout time.Duration) error {
+	compiler, err := newCompilerWithOptionalDecryptor(&cfg, cfg.IdentityFiles)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubecfg/render_test.go
+++ b/cmd/kubecfg/render_test.go
@@ -124,7 +124,7 @@ func TestRunRenderCmdFzfNoSelectionIsNoOp(t *testing.T) {
 		return fzf.ExitNoMatch, nil
 	}
 
-	err := runRenderCmdFzf(context.Background(), "", false, "", time.Second)
+	err := runRenderCmdFzf(context.Background(), "", false, time.Second)
 	require.NoError(t, err)
 
 	_, err = os.Stat(targetPath)
@@ -153,7 +153,7 @@ func TestRunRenderCmdFzfUpdatesActiveConfigSymlink(t *testing.T) {
 		return fzf.ExitOk, nil
 	}
 
-	err := runRenderCmdFzf(context.Background(), "", false, "", time.Second)
+	err := runRenderCmdFzf(context.Background(), "", false, time.Second)
 	require.NoError(t, err)
 
 	linkPath := filepath.Join(tmpDir, "config")
@@ -164,7 +164,7 @@ func TestRunRenderCmdFzfUpdatesActiveConfigSymlink(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRunRenderCmdDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
+func TestRunRenderCmdDecryptsEncryptedTokenWithConfiguredIdentityFiles(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), "target-kubeconfig.yaml")
 	identityFile, encryptedToken := writeAgeIdentityAndEncryptedToken(t, "command-token")
 
@@ -174,8 +174,9 @@ func TestRunRenderCmdDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 	})
 
 	cfg = newEncryptedRenderCommandTestConfig(targetPath, encryptedToken)
+	cfg.IdentityFiles = []string{identityFile}
 
-	err := runRenderCmd(context.Background(), "work", "vgr", true, identityFile, time.Second)
+	err := runRenderCmd(context.Background(), "work", "vgr", true, time.Second)
 	require.NoError(t, err)
 
 	contents, err := os.ReadFile(targetPath)
@@ -184,7 +185,7 @@ func TestRunRenderCmdDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 	require.NotContains(t, string(contents), encryptedToken)
 }
 
-func TestRunRenderCmdFzfDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
+func TestRunRenderCmdFzfDecryptsEncryptedTokenWithConfiguredIdentityFiles(t *testing.T) {
 	t.Setenv("FZF_DEFAULT_OPTS", "")
 	t.Setenv("FZF_DEFAULT_OPTS_FILE", "")
 
@@ -200,6 +201,7 @@ func TestRunRenderCmdFzfDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 	})
 
 	cfg = newEncryptedRenderCommandTestConfig(targetPath, encryptedToken)
+	cfg.IdentityFiles = []string{identityFile}
 	fzfRun = func(options *fzf.Options) (int, error) {
 		for range options.Input {
 		}
@@ -207,7 +209,7 @@ func TestRunRenderCmdFzfDecryptsEncryptedTokenWithIdentityFile(t *testing.T) {
 		return fzf.ExitOk, nil
 	}
 
-	err := runRenderCmdFzf(context.Background(), "", true, identityFile, time.Second)
+	err := runRenderCmdFzf(context.Background(), "", true, time.Second)
 	require.NoError(t, err)
 
 	contents, err := os.ReadFile(targetPath)
@@ -231,7 +233,7 @@ func TestRunRenderCmdImportsReferencedContext(t *testing.T) {
 	loginStdout = &bytes.Buffer{}
 	loginStderr = &bytes.Buffer{}
 
-	err := runRenderCmd(context.Background(), "work", "vgr", false, "", time.Second)
+	err := runRenderCmd(context.Background(), "work", "vgr", false, time.Second)
 	require.NoError(t, err)
 
 	loaded, err := clientcmd.LoadFromFile(targetPath)
@@ -260,7 +262,7 @@ func TestRunRenderCmdImportsImplicitClusterAndAuthInfo(t *testing.T) {
 	loginStdout = &bytes.Buffer{}
 	loginStderr = &bytes.Buffer{}
 
-	err := runRenderCmd(context.Background(), "work", "vgr", false, "", time.Second)
+	err := runRenderCmd(context.Background(), "work", "vgr", false, time.Second)
 	require.NoError(t, err)
 
 	loaded, err := clientcmd.LoadFromFile(targetPath)
@@ -286,7 +288,7 @@ func TestRunRenderCmdFailsWhenImportedContextIsMissing(t *testing.T) {
 	loginStdout = &bytes.Buffer{}
 	loginStderr = &bytes.Buffer{}
 
-	err := runRenderCmd(context.Background(), "work", "vgr", false, "", time.Second)
+	err := runRenderCmd(context.Background(), "work", "vgr", false, time.Second)
 	require.EqualError(t, err, "kubeconfig \"vgr\" context \"ctx1\" imports missing context \"missing\" from login source \"shared\"")
 }
 
@@ -307,7 +309,7 @@ func TestRunRenderCmdReturnsHelpfulErrorWhenLoginCommandCannotStart(t *testing.T
 	loginStdout = &bytes.Buffer{}
 	loginStderr = &bytes.Buffer{}
 
-	err := runRenderCmd(context.Background(), "work", "vgr", false, "", time.Second)
+	err := runRenderCmd(context.Background(), "work", "vgr", false, time.Second)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "login source \"shared\": run command")
 	require.Contains(t, err.Error(), "missing-login-binary")
@@ -330,7 +332,7 @@ func TestRunRenderCmdReturnsHelpfulErrorWhenGeneratedKubeconfigIsInvalid(t *test
 	loginStdout = &bytes.Buffer{}
 	loginStderr = &bytes.Buffer{}
 
-	err := runRenderCmd(context.Background(), "work", "vgr", false, "", time.Second)
+	err := runRenderCmd(context.Background(), "work", "vgr", false, time.Second)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "login source \"shared\": load generated kubeconfig")
 	require.Contains(t, err.Error(), "cannot unmarshal string")

--- a/examples/vmware-tanzu.md
+++ b/examples/vmware-tanzu.md
@@ -62,8 +62,8 @@ kubecfg render tanzu
 If your config contains encrypted auth fields elsewhere in the kubeconfig definition, provide the age identity used to decrypt them during compile:
 
 ```bash
-kubecfg login tanzu supervisor-prod --identity-file ~/.config/kubecfg/age.txt
-kubecfg render tanzu --identity-file ~/.config/kubecfg/age.txt
+kubecfg login tanzu supervisor-prod
+kubecfg render tanzu
 ```
 
 `kubecfg render` runs configured login sources by default before writing the final kubeconfig. Use `--skip-login` only when you intentionally want to reuse previously imported credentials.

--- a/pkg/config/compile.go
+++ b/pkg/config/compile.go
@@ -39,7 +39,7 @@ func (c *Compiler) Compile(cfg *Config) (*RuntimeConfig, error) {
 
 	rt := &RuntimeConfig{
 		Version:           cfg.Version,
-		BaseDir:           resolvePath("", cfg.BaseDir),
+		BaseDir:           ResolvePath("", cfg.BaseDir),
 		Workspaces:        make(map[string]*RuntimeWorkspace),
 		Kubeconfigs:       make(map[string]*RuntimeKubeconfig),
 		KubeconfigAliases: make(map[string]*RuntimeKubeconfig),
@@ -78,7 +78,7 @@ func (c *Compiler) compileKubeconfigs(rt *RuntimeConfig, cfg *Config) error {
 
 		rkc := &RuntimeKubeconfig{
 			Name:             kubeconfigName,
-			Path:             resolvePath(rt.BaseDir, kubeconfig.Path),
+			Path:             ResolvePath(rt.BaseDir, kubeconfig.Path),
 			Protected:        kubeconfig.Protected,
 			Aliases:          append([]string(nil), kubeconfig.Aliases...),
 			DefaultNamespace: strings.TrimSpace(kubeconfig.DefaultNamespace),
@@ -629,7 +629,7 @@ func resolveKubeconfigDefaultContext(rkc *RuntimeKubeconfig, value string) error
 	return nil
 }
 
-func resolvePath(base, path string) string {
+func ResolvePath(base, path string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return ""
@@ -681,7 +681,7 @@ func (c *AuthInfoCompiler) Compile(name string, in *AuthInfo) (*RuntimeAuthInfo,
 	}
 
 	if in.HasEncryptedFields() && c.Decryptor == nil {
-		return nil, fmt.Errorf("authinfo %q contains encrypted fields; provide --identity-file or a passphrase", name)
+		return nil, fmt.Errorf("authinfo %q contains encrypted fields; configure identity_files or provide a passphrase", name)
 	}
 
 	execConfig, err := resolveAuthInfosExec(in.Exec)

--- a/pkg/config/compile_test.go
+++ b/pkg/config/compile_test.go
@@ -23,7 +23,7 @@ func TestCompileFailsWhenEncryptedFieldsExistWithoutDecryptor(t *testing.T) {
 	}
 
 	_, err := NewCompiler().Compile(&cfg)
-	require.EqualError(t, err, "authinfo \"user\" contains encrypted fields; provide --identity-file or a passphrase")
+	require.EqualError(t, err, "authinfo \"user\" contains encrypted fields; configure identity_files or provide a passphrase")
 }
 
 func TestCompileEncryptedTokenOverridesPlaintextToken(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Workspaces       map[string]*Workspace  `mapstructure:"workspaces,omitempty" json:"workspaces,omitempty" yaml:"workspaces,omitempty"`
 	Kubeconfigs      map[string]*Kubeconfig `mapstructure:"kubeconfigs,omitempty" json:"kubeconfigs,omitempty" yaml:"kubeconfigs,omitempty"`
 	BaseDir          string                 `mapstructure:"base_dir,omitempty" json:"base_dir,omitempty" yaml:"base_dir,omitempty"`
+	IdentityFiles    []string               `mapstructure:"identity_files,omitempty" json:"identity_files,omitempty" yaml:"identity_files,omitempty"`
 }
 
 type Workspace struct {


### PR DESCRIPTION
Add identity_files to config for non-interactive decryption of encrypted fields. Update commands and docs to use configured identity files instead of --identity-file. This enables seamless decryption across all commands and simplifies usage.